### PR TITLE
Fix typo in user activation resource location

### DIFF
--- a/classes/OssnUser.php
+++ b/classes/OssnUser.php
@@ -64,7 +64,7 @@ class OssnUser extends OssnEntities {
                     $this->add();
                 }
                 if ($this->sendactiviation == true) {
-                    $link = ossn_site_url("uservalidate/acitvate/{$guid}/{$activation}");
+                    $link = ossn_site_url("uservalidate/activate/{$guid}/{$activation}");
                     $sitename = ossn_site_settings('site_name');
                     $activation = ossn_print('ossn:add:user:mai:body', array(
                         $sitename,
@@ -669,7 +669,7 @@ class OssnUser extends OssnEntities {
 	public function resendValidationEmail(){
 		self::initAttributes();
 		if(!$this->isUserVALIDATED()){
-			$link = ossn_site_url("uservalidate/acitvate/{$this->guid}/{$this->activation}");
+			$link = ossn_site_url("uservalidate/activate/{$this->guid}/{$this->activation}");
 			$sitename = ossn_site_settings('site_name');
 			$activation = ossn_print('ossn:add:user:mai:body', array(
                         $sitename,

--- a/libraries/ossn.lib.users.php
+++ b/libraries/ossn.lib.users.php
@@ -278,7 +278,7 @@ function ossn_uservalidate_pagehandler($pages) {
         echo ossn_error_page();
     }
     switch ($page) {
-        case 'acitvate':
+        case 'activate':
             if (!empty($pages[1]) && !empty($pages[2])) {
                 $user = new OssnUser;
                 $user->guid = $pages[1];


### PR DESCRIPTION
Correction of simple typo in order to avoid the suspicious of bad link