### PR TITLE
display tinymce menu according to Ossn language

### DIFF
--- a/themes/default/page/administrator.php
+++ b/themes/default/page/administrator.php
@@ -42,6 +42,7 @@ if (isset($params['contents'])) {
             plugins: "code image media link emoticons fullscreen insertdatetime print spellchecker preview",
             convert_urls: false,
             relative_urls: false,
+            language: "<?php echo ossn_site_settings('language'); ?>",
         });
     </script>
 


### PR DESCRIPTION
verified: tinymce will fall back to English without hassle if chosen language file is not in place; 
no further checking necessary here.
(I'll include tinymce's German language file in my next zip archive)