### PR TITLE
friends and public mistakenly swapped

### DIFF
--- a/components/OssnWall/forms/administrator/settings.php
+++ b/components/OssnWall/forms/administrator/settings.php
@@ -20,7 +20,7 @@
 		$public = 'selected';
 	}
 	?>
- 	<option value="friends" <?php echo $friends;?>><?php echo ossn_print('ossn:wall:allsite:posts');?></option>
-    <option value="public" <?php echo $public;?>><?php echo ossn_print('user:friends');?></option>
+ 	<option value="friends" <?php echo $friends;?>><?php echo ossn_print('user:friends');?></option>
+    <option value="public" <?php echo $public;?>><?php echo ossn_print('public');?></option>
  </select>
  <input type="submit" value="<?php echo ossn_print("save");?>" class="ossn-admin-button button-dark-blue"/>


### PR DESCRIPTION
couldn't really make friends with 'ossn:wall:allsite:posts'. If I understand the meaning correctly, this setting toggles the visibility of postings. And the posting is either visible for the public or for friends. Perhaps 'friends only' would be better.