### PR TITLE
replacing hardcoded 'checked' from core privacy

### DIFF
--- a/components/OssnWall/forms/privacy.php
+++ b/components/OssnWall/forms/privacy.php
@@ -9,4 +9,25 @@
  * @link      http://www.opensource-socialnetwork.com/licence
  */
 echo '<div style="font-size:12px;">' . ossn_print('post:select:privacy') . '</div>';
-echo ossn_view('system/templates/privacy');
+?>
+<div class="ossn-privacy">
+    <table border="0">
+        <tr>
+            <td style="vertical-align:top;">
+                <label><?php echo ossn_print('privacy'); ?></label>
+
+            </td>
+            <td>
+                <input id="radio-public-privacy" type="radio" name="privacy" value="2"/>
+                <span><?php echo ossn_print('public'); ?></span>
+
+                <p> <?php echo ossn_print('privacy:public:note'); ?> </p>
+
+                <input id="radio-private-privacy" type="radio" name="privacy" value="3"/>
+                <span><?php echo ossn_print('friends'); ?></span>
+
+                <p> <?php echo ossn_print('privacy:friends:note'); ?> </p>
+            </td>
+        </tr>
+    </table>
+</div>


### PR DESCRIPTION
'checked' will handled by jquery now in js/ossn_wall
- on homewall: according to Wall configuration retrieved from database
- on userwall: according to still hardcoded setting in forms/user/container