### PR TITLE
slow down update count to once a minute

### DIFF
--- a/components/OssnNotifications/js/OssnNotifications.php
+++ b/components/OssnNotifications/js/OssnNotifications.php
@@ -117,6 +117,7 @@ Ossn.AddFriend = function($guid) {
                 $('#notification-friend-item-' + $guid).find('form').show();
                 $('#ossn-nfriends-' + $guid).find('.ossn-loading').remove();
             }
+            Ossn.NotificationsCheck();
         }
     });
 };
@@ -141,6 +142,7 @@ Ossn.removeFriendRequset = function($guid) {
                 $('#notification-friend-item-' + $guid).find('form').show();
                 $('#ossn-nfriends-' + $guid).find('.ossn-loading').remove();
             }
+            Ossn.NotificationsCheck();
         }
     });
 };
@@ -233,6 +235,6 @@ Ossn.RegisterStartupFunction(function() {
     $(document).ready(function() {
         setInterval(function() {
             Ossn.NotificationsCheck()
-        }, 5000);
+        }, 5000 * 12);
     });
 });


### PR DESCRIPTION
- in order to reduce db stress
- on friend requests confirm/deny: don't wait for next update count - decrement counter in realtime
(no need to do this on other counters - they get updated the old way correctly by page reloads)