### PR TITLE
make postings more readabable again

### DIFF
--- a/components/OssnWall/css/wall.php
+++ b/components/OssnWall/css/wall.php
@@ -108,7 +108,6 @@
 	margin-top: 10px;
 	width: 500px;
 	line-height: 20px;
-	word-break: break-all;
 }
 
 .activity-item-container .description img {


### PR DESCRIPTION
Please revert. The "long line" issue was very much a theoretical one. Nobody would post that long words in reality. And the big disadvantage of the current view is that all posting are hardly readable.
There's only one real situation where we might get that long lines: URLs
That's why I put it into linkify now.
(The Readmore css has to be changed accordlingly!)