### PR TITLE
fix for #374

### DIFF
--- a/components/OssnWall/actions/wall/post/delete.php
+++ b/components/OssnWall/actions/wall/post/delete.php
@@ -12,7 +12,7 @@ $ossnwall = new OssnWall;
 $id = input('post');
 $post = $ossnwall->GetPost($id);
 if ($post->type == 'user' && !ossn_isAdminLoggedin()) {
-    if ($post->poster_guid !== ossn_loggedin_user()->guid) {
+    if ($post->poster_guid !== ossn_loggedin_user()->guid && $post->owner_guid !== ossn_loggedin_user()->guid) {
         if (!ossn_is_xhr()) {
             ossn_trigger_message(ossn_print('post:delete:fail'), 'error');
             redirect(REF);


### PR DESCRIPTION
I think this has been closed because of misunderstandings:
Actually, a normal user HAS the option to delete a posting from a friend.
But it wasn't working because the "normal user" case was missing here.