### PR TITLE
fix issue #601

### DIFF
--- a/components/OssnComments/ossn_com.php
+++ b/components/OssnComments/ossn_com.php
@@ -147,6 +147,7 @@ function ossn_comment_menu($name, $type, $params) {
             }
         }
     }
+    ossn_unregister_menu('delete', 'comments');
 	$user = ossn_loggedin_user();
 	if(ossn_isLoggedin()){
 	  if($comment->type == 'comments:entity'){


### PR DESCRIPTION
remove orphaned 'delete' menu entries leading to wrong actions
(besides that, the part below includes an unnessary permission check even if the comment is not of type 'entity')