### PR TITLE
#605 partly fixed, but still issues

### DIFF
--- a/components/OssnComments/ossn_com.php
+++ b/components/OssnComments/ossn_com.php
@@ -136,7 +136,8 @@ function ossn_comment_menu($name, $type, $params) {
 			}
 			//group admins must be able to delete ANY comment in their own group #170
 			//just show menu if group owner is loggedin 
-            if ((ossn_loggedin_user()->guid == $post->owner_guid) || (ossn_loggedin_user()->guid == $group->owner_guid)) {
+            if ((ossn_loggedin_user()->guid == $post->owner_guid) || (ossn_loggedin_user()->guid == $comment->owner_guid)
+            || (ossn_loggedin_user()->guid == $group->owner_guid)) {
                 ossn_unregister_menu('delete', 'comments');
 				ossn_register_menu_item('comments', array(
 					'name' => 'delete',
@@ -147,23 +148,21 @@ function ossn_comment_menu($name, $type, $params) {
             }
         }
     }
-    ossn_unregister_menu('delete', 'comments');
-	$user = ossn_loggedin_user();
-	if(ossn_isLoggedin()){
-	  if($comment->type == 'comments:entity'){
-		$entity = ossn_get_entity($comment->subject_guid);  
-	  }
-      if (($user->guid == $params['owner_guid']) || ossn_isAdminLoggedin() 
-		|| ($comment->type == 'comments:entity' && $entity->type = 'user' && $user->guid == $entity->owner_guid)) {
-         ossn_unregister_menu('delete', 'comments');
-		 ossn_register_menu_item('comments', array(
-			  'name' => 'delete',
-              'href' => ossn_site_url("action/delete/comment?comment={$params['id']}", true),
-              'class' => 'ossn-delete-comment',
-			  'text' => ossn_print('comment:delete'),
-          ));
-      
-	  }
+	  $user = ossn_loggedin_user();
+	  if(ossn_isLoggedin()){
+	    if($comment->type == 'comments:entity') {
+	      $entity = ossn_get_entity($comment->subject_guid);
+	      ossn_unregister_menu('delete', 'comments');
+	      if (($user->guid == $params['owner_guid']) || ossn_isAdminLoggedin()
+	      || ($comment->type == 'comments:entity' && $entity->type = 'user' && $user->guid == $entity->owner_guid)) {
+	        ossn_register_menu_item('comments', array(
+	          'name' => 'delete',
+	          'href' => ossn_site_url("action/delete/comment?comment={$params['id']}", true),
+	          'class' => 'ossn-delete-comment',
+	          'text' => ossn_print('comment:delete'),
+	          ));
+	      }
+	   }
 	}
 }
 


### PR DESCRIPTION
sorry, we had a bad side effect with the first fix
1. moved ossn_unregister_menu from line 150 into "if type == 'comments:entity' condition
because otherwise 'delete menus' are removed from type == 'comments:posts'
2. added || (ossn_loggedin_user()->guid == $comment->owner_guid) to type == 'comments:posts'
otherwise we can't delete our own comment from a posting which is owned by someone else