### PR TITLE
a result can be of type 'groups', but not a new (search) action

### DIFF
--- a/components/OssnGroups/ossn_com.php
+++ b/components/OssnGroups/ossn_com.php
@@ -140,7 +140,7 @@ function ossn_group_search_link($event, $type, $params) {
 		$url = OssnPagination::constructUrlArgs(array(
 				'type'
 		));
-		ossn_register_menu_link('groups', 'search:groups', "search?type=groups{$url}", 'search');
+		ossn_register_menu_link('groups', 'groups', "search?type=groups{$url}", 'search');
 }
 
 /**


### PR DESCRIPTION
icon name in OssnSearch has to be changed from search-groups.png to groups.png, too. Otherwise the icon is missing in Oinitial.