### PR TITLE
do capitalization of copyright by css

### DIFF
--- a/libraries/ossn.lib.initialize.php
+++ b/libraries/ossn.lib.initialize.php
@@ -55,7 +55,7 @@ function ossn_initialize() {
 		
 		ossn_register_menu_item('footer', array(
 				'name' => 'a_copyrights',
-				'text' => ossn_print('copyright') . ' ' . strtoupper(ossn_site_settings('site_name')),
+				'text' => ossn_print('copyright') . ' ' . ossn_site_settings('site_name'),
 				'href' => ossn_site_url()
 		));
 		


### PR DESCRIPTION
otherwise special chars are getting scrambled, see #717