### PR TITLE
last 1 of 2 occurrences of stroupper removed

### DIFF
--- a/components/OssnPhotos/ossn_com.php
+++ b/components/OssnPhotos/ossn_com.php
@@ -147,7 +147,7 @@ function ossn_photos_sizes() {
 function profile_modules_albums($hook, $type, $module, $params) {
 		$user['user'] = $params['user'];
 		$content      = ossn_plugin_view("photos/modules/profile/albums", $user);
-		$title        = strtoupper(ossn_print('photo:albums'));
+		$title        = ossn_print('photo:albums');
 		
 		$module[] = ossn_view_widget(array(
 				'title' => $title,


### PR DESCRIPTION
because of wrong special-chars handling
it should be checked, whether to add 'text-transform: uppercase' to widget-heading instead, or not. There are a lot of other headers not capitalitezed, though... So perhaps we should leave widget uncapitalized ...