### PR TITLE
refactoring to show group postings on main timeline

### DIFF
--- a/components/OssnWall/plugins/default/wall/siteactivity.php
+++ b/components/OssnWall/plugins/default/wall/siteactivity.php
@@ -10,42 +10,56 @@
  */
 $wall       = new OssnWall;
 $group      = new OssnGroup;
-$accesstype = ossn_get_homepage_wall_access();
-if($accesstype == 'public' || ossn_isAdminLoggedin()) {
-		$posts = $wall->GetPosts(array(
-				// 'type' => 'user'
-				// get users AND groups here
-		));
-		$count = $wall->GetPosts(array(
-				'count' => true
-		));
-} elseif($accesstype == 'friends') {
-		$posts = $wall->getFriendsPosts();
-		$count = $wall->getFriendsPosts(array(
-				'count' => true
-		));
-}
+
+$posts = $wall->GetPosts();
+$count = $wall->GetPosts(array(
+	'count' => true
+));
+
+$accesstype = ossn_get_homepage_wall_access();		
 $loggedinuser = ossn_loggedin_user();
+
 if($posts) {
-		foreach($posts as $post) {
-				$item = ossn_wallpost_to_item($post);
-				
-				$user = ossn_user_by_guid($post->poster_guid);
-				if($post->access == OSSN_FRIENDS) {
-						if(ossn_user_is_friend(ossn_loggedin_user()->guid, $post->owner_guid) || $loggedinuser->guid == $post->owner_guid || $loggedinuser->canModerate()) {
-								echo ossn_wall_view_template($item);
-						}
+	foreach($posts as $post) {
+		$item = ossn_wallpost_to_item($post);
+		$user = ossn_user_by_guid($post->poster_guid);
+
+		if($accesstype == 'public') {
+			// wall type 'All Site Posts'
+			if($post->access == OSSN_PUBLIC) {
+				// show all public posts of type 'user'
+				echo ossn_wall_view_template($item);
+			} elseif($post->access == OSSN_PRIVATE) {
+				// show all postings of all groups which I'm a member of
+				// groups make no public/friends-only difference
+				if ($group->isMember($post->owner_guid, ossn_loggedin_user()->guid) || $loggedinuser->canModerate()) {
+					echo ossn_wall_view_template($item);
 				}
-				if($post->access == OSSN_PUBLIC) {
-						echo ossn_wall_view_template($item);
+			} else {
+				// finally show postings of type 'user' which visibility is restricted to friends only
+				// which may include my own 'friends-only' postings, too
+				if(ossn_user_is_friend(ossn_loggedin_user()->guid, $post->owner_guid) || $loggedinuser->guid == $post->owner_guid || $loggedinuser->canModerate()) {
+					echo ossn_wall_view_template($item);
 				}
-				if($post->access == OSSN_PRIVATE) { // the group records
-					if ($group->isMember($post->owner_guid, ossn_loggedin_user()->guid)) {
-						// calling isMember each time ... au weia :(
+			}
+		} elseif($accesstype == 'friends') {
+			// wall type 'Friends Posts'
+			if($post->access == OSSN_PUBLIC || $post->access == OSSN_FRIENDS) {
+				// show only friend's and own postings of type 'user'
+				if(ossn_user_is_friend(ossn_loggedin_user()->guid, $post->owner_guid) || $loggedinuser->guid == $post->owner_guid || $loggedinuser->canModerate()) {
+					echo ossn_wall_view_template($item);
+				}
+			} elseif($post->access == OSSN_PRIVATE) { 
+				// in case of type 'group'
+				if ($group->isMember($post->owner_guid, ossn_loggedin_user()->guid) || $loggedinuser->canModerate()) { 
+					// first check membership
+					if(ossn_user_is_friend(ossn_loggedin_user()->guid, $post->poster_guid) || $loggedinuser->guid == $post->poster_guid || $loggedinuser->canModerate()) {
+						// then show only friend's and own postings in that group
 						echo ossn_wall_view_template($item);
 					}
 				}
+			}
 		}
-		
+	}
 }
 echo ossn_view_pagination($count);


### PR DESCRIPTION
still unsolved: issue with pagination tab, because the _real_ number of posting to display is not known in advance
currently, _all_ records are counted
(will be changed later when more sophisticated selects are available)