### PR TITLE
prevent overlapping right border

### DIFF
--- a/components/OssnPhotos/plugins/default/css/photos.php
+++ b/components/OssnPhotos/plugins/default/css/photos.php
@@ -32,6 +32,7 @@
 }
 .ossn-photos {} .ossn-photos li img {
     /* border:1px solid #ccc; */
+    max-width: 100%;
 }
 .ossn-photos h2 {
     text-align: center;


### PR DESCRIPTION
on page /u/USERNAME/photos

and please check, if .ossn-photos {} is really meant this way