### PR TITLE
if not explicitely set, set page_limit to false

### DIFF
--- a/components/OssnComments/classes/OssnComments.php
+++ b/components/OssnComments/classes/OssnComments.php
@@ -133,8 +133,11 @@ class OssnComments extends OssnAnnotation {
 				$vars['type']         = "comments:{$type}";
 				$vars['order_by']     = 'a.id DESC';
 				$vars['limit']        = $this->limit;
-				if($this->page_limit === false) {
-						$vars['page_limit'] = $this->page_limit;
+				if(!isset($this->page_limit) || $this->page_limit === false) {
+					$vars['page_limit'] = false;
+				}
+				else {
+					$vars['page_limit'] = $this->page_limit;
 				}
 				$comments = $this->searchAnnotation($vars);
 				if(!empty($comments)) {


### PR DESCRIPTION
otherwise offset calculation will be triggered in searchAnnotation()
and we don't see no comments on pages > 1