### PR TITLE
return object instead of array with object

### DIFF
--- a/components/OssnComments/classes/OssnComments.php
+++ b/components/OssnComments/classes/OssnComments.php
@@ -99,10 +99,11 @@ class OssnComments extends OssnAnnotation {
 				if(empty($id)){
 					return false;
 				}
-				return $this->searchAnnotation(array(
+				$res_array = $this->searchAnnotation(array(
 						'annotation_id' => $id,
 						'offset' => input('comments_offset', '', 1),
 				));
+				return $res_array[0];
 		}
 		
 		/**


### PR DESCRIPTION
to preserve compatibility with former code