### PR TITLE
divs must not be nested in paragraphs

### DIFF
--- a/components/OssnEmbed/libraries/ossnembed.lib.php
+++ b/components/OssnEmbed/libraries/ossnembed.lib.php
@@ -104,7 +104,7 @@ function ossn_embed_add_css($guid, $width, $height) {
  * @return string <object> code
  */
 function ossn_embed_add_object($type, $url, $guid, $width, $height) {
-	$videodiv = "<div id=\"ossnembed{$guid}\" class=\"ossn_embed_video embed-responsive embed-responsive-16by9\">";
+	$videodiv = "<span id=\"ossnembed{$guid}\" class=\"ossn_embed_video embed-responsive embed-responsive-16by9\">";
 
 	// could move these into an array and use sprintf
 	switch ($type) {
@@ -135,7 +135,7 @@ function ossn_embed_add_object($type, $url, $guid, $width, $height) {
 			break;
 	}
 
-	$videodiv .= "</div>";
+	$videodiv .= "</span>";
 	// re-open post-text again (last closing </div> comes with wall code as before )
 	// hmm no need for div post-text without ending tag , removed it from here and removed ending tag from ossn_embed_add_css() 
 	// $arsalanshah 12/4/2015


### PR DESCRIPTION
in a wall posting we currently have

`<div class="post-contents"><p>some text... some more text...</p></div>`

embedding a video with an unallowed div makes the browser inserting a closing and opening p like

`<div class="post-contents"><p>some text... </p><div>embedded video</div>some more text...<p></p></div>`

which leads to differently formatted text below the video

if necessary, a span style display:block may be added