### PR TITLE
Can use another db port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /.htaccess
 Thumbs.db
 Desktop.ini
+DISPLAY_ERRORS
+error_log
 
 #do not ignore ossn core components
 !/components/OssnAds

--- a/classes/OssnDatabase.php
+++ b/classes/OssnDatabase.php
@@ -17,7 +17,7 @@ class OssnDatabase extends OssnBase {
 		 */
 		public function Connect() {
 				$settings = ossn_database_settings();
-				$connect  = new mysqli($settings->host, $settings->user, $settings->password, $settings->database);
+				$connect  = new mysqli($settings->host, $settings->user, $settings->password, $settings->database, $settings->port);
 				if(!$connect->connect_errno) {
 						return $connect;
 				} else {

--- a/configurations/ossn.config.db.example.php
+++ b/configurations/ossn.config.db.example.php
@@ -13,6 +13,9 @@
 // replace <<host>> with your database host name;
 $Ossn->host = '<<host>>';
 
+// replace <<port>> with your database host name;
+$Ossn->port = '<<port>>';
+
 // replace <<user>> with your database username;
 $Ossn->user = '<<user>>';
 

--- a/installation/classes/OssnInstall.php
+++ b/installation/classes/OssnInstall.php
@@ -188,10 +188,36 @@ class OssnInstallation {
 		 *
 		 */
 		public function dbhost($dbhost) {
+				preg_match('/([\w-\.]+)(|\:(\d+))$/', $dbhost, $matches);
+				
+				//set the host without port
+				if(isset($matches[1])){
+					$dbhost = $matches[1];
+				}
+
 				if(!empty($dbhost)) {
 						$this->dbhost = $dbhost;
 				} else {
 						$this->dbhost = 'localhost';
+				}
+				
+				//set the port
+				if(isset($matches[3])){
+					$this->dbport($matches[3]);
+				}
+		}
+
+		/**
+		 * Get db host;
+		 * @last edit: $arsalanshah
+		 * @Reason: Initial;
+		 *
+		 */
+		public function dbport($dbport) {
+				if(!empty($dbport)) {
+						$this->dbport = $dbport;
+				} else {
+						$this->dbport = '3306';
 				}
 		}
 		
@@ -291,7 +317,7 @@ class OssnInstallation {
 		 * @Reason: Initial;
 		 */
 		public function dbconnect() {
-				$connect = new mysqli($this->dbhost, $this->dbusername, $this->dbpassword, $this->dbname);
+				$connect = new mysqli($this->dbhost, $this->dbusername, $this->dbpassword, $this->dbname, $this->dbport);
 				if($connect->connect_errno) {
 						$this->connect_err->connect_errn = mysqli_connect_error();
 						return false;
@@ -309,6 +335,7 @@ class OssnInstallation {
 		function configurations_db() {
 				$params       = array(
 						'host' => $this->dbhost,
+						'port' => $this->dbport,
 						'user' => $this->dbusername,
 						'password' => $this->dbpassword,
 						'dbname' => $this->dbname

--- a/libraries/ossn.lib.system.php
+++ b/libraries/ossn.lib.system.php
@@ -85,18 +85,13 @@ function ossn_get_userdata($extend = '') {
  */
 function ossn_database_settings() {
     global $Ossn;
-    if(!isset($Ossn->port)){
-        $Ossn->port = '3306';
-    }
-    
     $defaults = array(
         'host' => $Ossn->host,
+        'port' => $Ossn->port,
         'user' => $Ossn->user,
         'password' => $Ossn->password,
-        'database' => $Ossn->database,
-        'port' => $Ossn->port
+        'database' => $Ossn->database
     );
-
     return arrayObject($defaults);
 }
 
@@ -671,11 +666,11 @@ function ossn_errros() {
         error_reporting(E_NOTICE ^ ~E_WARNING);
 
         ini_set('log_errors', 1);		
-	ini_set('error_log', ossn_route()->www . 'error_log');
+	    ini_set('error_log', ossn_route()->www . 'error_log');
 
-	set_error_handler('_ossn_php_error_handler');
+	   set_error_handler('_ossn_php_error_handler');
     } elseif ($settings !== 'on') {
-	ini_set("log_errors", 0);
+	   ini_set("log_errors", 0);
         ini_set('display_errors', 'off');
     } 
 }

--- a/libraries/ossn.lib.system.php
+++ b/libraries/ossn.lib.system.php
@@ -85,12 +85,18 @@ function ossn_get_userdata($extend = '') {
  */
 function ossn_database_settings() {
     global $Ossn;
+    if(!isset($Ossn->port)){
+        $Ossn->port = '3306';
+    }
+    
     $defaults = array(
         'host' => $Ossn->host,
         'user' => $Ossn->user,
         'password' => $Ossn->password,
-        'database' => $Ossn->database
+        'database' => $Ossn->database,
+        'port' => $Ossn->port
     );
+
     return arrayObject($defaults);
 }
 

--- a/port
+++ b/port
@@ -1,3 +1,0 @@
-[feature_can_use_db_port b7a278b] Now you can connect the database to a different port instead the default. In the configuration file (configurations/ossn.config.db.php), just add -
- 3 files changed, 8 insertions(+), 2 deletions(-)
- create mode 100644 port

--- a/port
+++ b/port
@@ -1,0 +1,3 @@
+[feature_can_use_db_port b7a278b] Now you can connect the database to a different port instead the default. In the configuration file (configurations/ossn.config.db.php), just add -
+ 3 files changed, 8 insertions(+), 2 deletions(-)
+ create mode 100644 port


### PR DESCRIPTION
Now you can connect the database to a different port instead the default. In the configuration file ("configurations/ossn.config.db.php"), just add \"$Ossn->port = '3310';\" or another port of your choice.

**This option was not adeed in the installation screen, only at the config file.**