### PR TITLE
Don't show private posts when friend request is pending but still unc…

### DIFF
--- a/components/OssnWall/plugins/default/wall/user/wall.php
+++ b/components/OssnWall/plugins/default/wall/user/wall.php
@@ -48,7 +48,7 @@ if($posts) {
 				$user = ossn_user_by_guid($post->poster_guid);
 				if($post->access == OSSN_FRIENDS) {
 						//lastchage: site admins are unable to access member profile threads without friendship #176 
-						if(ossn_user_is_friend(ossn_loggedin_user()->guid, $post->owner_guid) || ossn_loggedin_user()->guid == $post->owner_guid || ossn_isAdminLoggedin()) {
+						if(ossn_user_is_friend($post->owner_guid, ossn_loggedin_user()->guid) || ossn_loggedin_user()->guid == $post->owner_guid || ossn_isAdminLoggedin()) {
 								echo ossn_plugin_view('wall/templates/activity-item', array(
 										'post' => $post,
 										'friends' => explode(',', $data->friend),


### PR DESCRIPTION


fix for #1039
if we want to stay with one-way relationship checks here, we need to check whether the POSTER has/wants a relation to the reader - not the opposite.
(Maybe we should consider adding the true/false flag to ossn_user_is_friend() in the future to check for recursive friendship if necessary?)