### PR TITLE
don't re-decode already correctly encoded entities

### DIFF
--- a/components/OssnMessages/classes/OssnMessages.php
+++ b/components/OssnMessages/classes/OssnMessages.php
@@ -23,9 +23,6 @@ class OssnMessages extends OssnDatabase {
 				if(empty($message)) {
 						return false;
 				}
-				//send valid text to database only no html tags
-				//missing reconversion of html escaped characters in messages #118
-				$message = html_entity_decode($message, ENT_QUOTES, "UTF-8");
 				$message = strip_tags($message);
 				$message = ossn_restore_new_lines($message);
 				$message = ossn_input_escape($message, false);


### PR DESCRIPTION
#118 has become obsolete because text input is no longer escaped as opposed to earlier Ossn