### PR TITLE
Delete a chat message functionality

### DIFF
--- a/components/OssnMessages/actions/message/send.php
+++ b/components/OssnMessages/actions/message/send.php
@@ -17,6 +17,7 @@ if ($send->send(ossn_loggedin_user()->guid, $to, $message)) {
 	
 	$params['user'] = $user;
     $params['message'] = $message;
+	$params['message_id']   = $send->lastMessage;	
     echo ossn_plugin_view('messages/templates/message-send', $params);
 
 } else {

--- a/components/OssnMessages/classes/OssnMessages.php
+++ b/components/OssnMessages/classes/OssnMessages.php
@@ -231,7 +231,7 @@ class OssnMessages extends OssnDatabase {
 						)
 				));
 		}
-	
+		
 		/**
 		 * Delete message by id
 		 *
@@ -253,5 +253,25 @@ class OssnMessages extends OssnDatabase {
 			}
 			return false;
 		}
-	
+		
+		/**
+		 * Get messages IDs by from user id
+		 *
+		 * @params  integer $from Users guid
+		 *
+		 * @return int|false
+		 */
+		public function fromList($from) {
+			if(empty($from)) {
+					return false;
+			}
+			$params['from']   = 'ossn_messages';
+			$params['wheres'] = array(
+				"message_from='{$from}'"
+			);
+			$params['params'] = array(
+				'id,viewed'
+			);
+			return $this->select($params, true);
+		}
 } //class

--- a/components/OssnMessages/classes/OssnMessages.php
+++ b/components/OssnMessages/classes/OssnMessages.php
@@ -71,8 +71,8 @@ class OssnMessages extends OssnDatabase {
 						1
 				);
 				$params['wheres'] = array(
-						"message_from='{$from}' AND
-								   message_to='{$to}'"
+						"message_from='{$from}' AND 
+						 message_to='{$to}'"
 				);
 				if($this->update($params)) {
 						return true;
@@ -90,9 +90,9 @@ class OssnMessages extends OssnDatabase {
 		 */
 		public function getNew($from, $to, $viewed = 0) {
 				$params['from']   = 'ossn_messages';
-				$params['wheres'] = array(
-						"message_from='{$from}' AND
-								   message_to='{$to}' AND viewed='{$viewed}'"
+				$params['wheres'] = array( "(status='0') AND ". 
+						"(message_from='{$from}' AND message_to='{$to}' AND 
+						  viewed='{$viewed}')"
 				);
 				return $this->select($params, true);
 		}
@@ -106,8 +106,10 @@ class OssnMessages extends OssnDatabase {
 		 */
 		public function recentChat($to) {
 				$params['from']     = 'ossn_messages';
-				$params['wheres']   = array(
-						"message_to='{$to}' OR message_from='{$to}'"
+				$params['wheres']   = array("(status='0') AND ". 
+						"(message_to='{$to}' OR 
+						  message_from='{$to}')"
+
 				);
 				$params['order_by'] = "id DESC";
 				$chats              = $this->select($params, true);
@@ -144,13 +146,16 @@ class OssnMessages extends OssnDatabase {
 		 *
 		 * @return object
 		 */
-		public function get($from, $to) {
+		public function get($from, $to, $status="0") {
+				if ($status=='all'){
+					$status='';
+				} else {
+					$status="(status='{$status}') AND ";
+				}
 				$params['from']     = 'ossn_messages';
-				$params['wheres']   = array(
-						"message_from='{$from}' AND
-								  message_to='{$to}' OR
-								  message_from='{$to}' AND
-								  message_to='{$from}'"
+				$params['wheres']   = array( $status.
+						"(message_from='{$from}' AND message_to='{$to}') OR
+						 (message_from='{$to}' AND message_to='{$from}')"
 				);
 				$params['order_by'] = "id ASC";
 				return $this->select($params, true);
@@ -165,8 +170,9 @@ class OssnMessages extends OssnDatabase {
 		 */
 		public function recentSent($from) {
 				$params['from']     = 'ossn_messages';
-				$params['wheres']   = array(
+				$params['wheres']   = array("(status='0') AND ". 
 						"message_from='{$from}'"
+
 				);
 				$params['order_by'] = "id DESC";
 				$c                  = $this->select($params, true);
@@ -185,7 +191,7 @@ class OssnMessages extends OssnDatabase {
 		 */
 		public function countUNREAD($to) {
 				$params['from']   = 'ossn_messages';
-				$params['wheres'] = array(
+				$params['wheres'] = array("(status='0') AND ". 
 						"message_to='{$to}' AND viewed='0'"
 				);
 				$params['params'] = array(
@@ -206,7 +212,7 @@ class OssnMessages extends OssnDatabase {
 				$params['wheres'] = array(
 						"id='{$id}'"
 				);
-				$get              = $this->select($params);
+				$get = $this->select($params);
 				if($get) {
 						return $get;
 				}
@@ -233,45 +239,56 @@ class OssnMessages extends OssnDatabase {
 		}
 		
 		/**
-		 * Delete message by id
+		 * Make sure status field is not null
 		 *
-		 * @params  integer $id ID of message
+		 * @params $from: User 1 guid
+		 *         $to User 2 guid
 		 *
-		 * @return object|false
+		 * @return bool
 		 */
-		public function deleteMessage($id) {
-			//first check if message exists
-			if (!$this->getMessage($id)){ return false; }
-			
-			$params['from']   = 'ossn_messages';
-			$params['wheres'] = array(
-				"id='{$id}'"
-			);
-			$delete = $this->delete($params);
-			if($delete) {
-				return $delete;
-			}
-			return false;
+		public function initStatus($guid) {
+				$params['table']  = 'ossn_messages';
+				$params['names']  = array(
+						'status'
+				);
+				$params['values'] = array(
+						'0'
+				);
+				$params['wheres'] = array("(status IS NULL OR status='') AND 
+						(message_from='{$guid}' OR message_to='{$guid}')"
+				);
+				if($this->update($params)) {
+						return true;
+				}
+				return false;
 		}
 		
 		/**
-		 * Get messages IDs by from user id
+		 * Set message status by id and status bit
 		 *
-		 * @params  integer $from Users guid
+		 * @params  integer $id ID of message
+		 * 			byte $status status of message
 		 *
-		 * @return int|false
+		 * @return object|false
 		 */
-		public function fromList($from) {
-			if(empty($from)) {
-					return false;
-			}
-			$params['from']   = 'ossn_messages';
+		public function setStatus($id,$status=0) { 
+			//first check if message exists
+			if (!$this->getMessage($id)){ return false; }
+
+			$item=$this->getMessage($id);
+			$status=($item->status | $status);
+
+			$params['table']  = 'ossn_messages';
+			$params['names']  = array('status');
+			$params['values'] = array($status);
 			$params['wheres'] = array(
-				"message_from='{$from}'"
+				"id='{$id}'"
 			);
-			$params['params'] = array(
-				'id,viewed'
-			);
-			return $this->select($params, true);
+			
+			if($this->update($params)) {
+				return true;
+			}
+
+			return false;
 		}
 } //class

--- a/components/OssnMessages/classes/OssnMessages.php
+++ b/components/OssnMessages/classes/OssnMessages.php
@@ -231,4 +231,27 @@ class OssnMessages extends OssnDatabase {
 						)
 				));
 		}
+	
+		/**
+		 * Delete message by id
+		 *
+		 * @params  integer $id ID of message
+		 *
+		 * @return object|false
+		 */
+		public function deleteMessage($id) {
+			//first check if message exists
+			if (!$this->getMessage($id)){ return false; }
+			
+			$params['from']   = 'ossn_messages';
+			$params['wheres'] = array(
+				"id='{$id}'"
+			);
+			$delete = $this->delete($params);
+			if($delete) {
+				return $delete;
+			}
+			return false;
+		}
+	
 } //class

--- a/components/OssnMessages/locale/ossn.de.php
+++ b/components/OssnMessages/locale/ossn.de.php
@@ -16,5 +16,8 @@ $de = array(
     'messages' => 'Nachrichten',
     'message:placeholder' => 'Schreib was ...',
     'no:messages' => 'keine Nachrichten vorhanden',
+	'delete:message' => 'Nachricht loschen',
+	'delete:all:messages' => 'Alle Nachrichten loschen',
+	'confirm:delete:messages' =>'Dadurch werden alle Nachrichten in dieser Liste geloscht. Willst du fortfahren?',
 );
 ossn_register_languages('de', $de); 

--- a/components/OssnMessages/locale/ossn.en.php
+++ b/components/OssnMessages/locale/ossn.en.php
@@ -15,6 +15,9 @@ $en = array(
     'ossn:message:between' => 'Messages %s',
     'messages' => 'Messages',
     'message:placeholder' => 'Enter text here',
-    'no:messages' => 'You have no message.'
+    'no:messages' => 'You have no message.',
+	'delete:message' => 'Delete message',
+	'delete:all:messages' => 'Delete all messages',
+	'confirm:delete:messages' =>'This will delete all messages in this list. Do you want to proceed?'
 );
 ossn_register_languages('en', $en); 

--- a/components/OssnMessages/locale/ossn.es.php
+++ b/components/OssnMessages/locale/ossn.es.php
@@ -17,6 +17,9 @@ $es = array(
     'ossn:message:between' => 'Mensajes %s',
     'messages' => 'Mensajes',
     'message:placeholder' => 'Introduzca el texto aquí',
-    'no:messages' => 'Usted no tiene ningún mensaje.'
+    'no:messages' => 'Usted no tiene ningún mensaje.',
+	'delete:message' => 'Borrar mensaje',
+	'delete:all:messages' => 'Eliminar todos los mensajes',
+	'confirm:delete:messages' =>'Esto eliminara todos los mensajes de esta lista. Quieres proceder?',	
 );
 ossn_register_languages('es', $es); 

--- a/components/OssnMessages/locale/ossn.fr.php
+++ b/components/OssnMessages/locale/ossn.fr.php
@@ -18,6 +18,6 @@ $fr = array(
 	'no:messages' => "Vous n'avez pas de messages.",
 	'delete:message' => 'Supprimer un message',
 	'delete:all:messages' => 'Supprimer tous les messages',
-	'confirm:delete:messages' =>'Cela supprimera tous les messages de cette liste. Voulez-vous poursuivre?'	
+	'confirm:delete:messages'=>'Cela supprimera tous les messages de cette liste. Voulez-vous poursuivre?'	
 );
 ossn_register_languages('fr', $fr); 

--- a/components/OssnMessages/locale/ossn.fr.php
+++ b/components/OssnMessages/locale/ossn.fr.php
@@ -15,6 +15,9 @@ $fr = array(
     'ossn:message:between' => 'Messages %s',
     'messages' => 'Messages',
     'message:placeholder' => 'Entrer votre texte ici',
-	'no:messages' => "Vous n'avez pas de messages."
+	'no:messages' => "Vous n'avez pas de messages.",
+	'delete:message' => 'Supprimer un message',
+	'delete:all:messages' => 'Supprimer tous les messages',
+	'confirm:delete:messages' =>'Cela supprimera tous les messages de cette liste. Voulez-vous poursuivre?'	
 );
 ossn_register_languages('fr', $fr); 

--- a/components/OssnMessages/locale/ossn.it.php
+++ b/components/OssnMessages/locale/ossn.it.php
@@ -15,6 +15,9 @@ $en = array(
     'ossn:message:between' => 'Messaggio da %s',
     'messages' => 'Messaggi',
     'message:placeholder' => 'Inserisci qui il testo',
-    'no:messages' => 'Non hai messaggi.'
+    'no:messages' => 'Non hai messaggi.',
+	'delete:message' => 'Elimina messaggio',
+	'delete:all:messages' => 'Elimina tutti i messaggi',
+	'confirm:delete:messages' =>'Questo eliminera tutti i messaggi in questo elenco. Vuoi procedere?'	
 );
 ossn_register_languages('it', $en); 

--- a/components/OssnMessages/locale/ossn.pt.php
+++ b/components/OssnMessages/locale/ossn.pt.php
@@ -15,6 +15,9 @@ $pt = array(
     'ossn:message:between' => 'Mensagem %s',
     'messages' => 'Mensagens',
     'message:placeholder' => 'Digite seu texto aqui',
-    'no:messages' => 'Você não possui mensagens.'
+    'no:messages' => 'Você não possui mensagens.',
+	'delete:message' => 'Apagar mensagem',
+	'delete:all:messages' => 'Apague todas as mensagens',
+	'confirm:delete:messages' =>'Isso eliminará todas as mensagens nesta lista. Você quer prosseguir?'	
 );
 ossn_register_languages('pt', $pt); 

--- a/components/OssnMessages/locale/ossn.ro.php
+++ b/components/OssnMessages/locale/ossn.ro.php
@@ -15,6 +15,9 @@ $ro = array(
     'ossn:message:between' => 'Mesaje %s',
     'messages' => 'Mesaje',
     'message:placeholder' => 'Scrie aici',
-    'no:messages' => 'Nu ai mesaje noi.'
+    'no:messages' => 'Nu ai mesaje noi.',
+	'delete:message' => 'Stergeti mesajul',
+	'delete:all:messages' => 'Stergeti toate mesajele',
+	'confirm:delete:messages' =>'Aceasta va sterge toate mesajele din aceasta lista. Doriti sa continuati?'	
 );
 ossn_register_languages('ro', $ro); 

--- a/components/OssnMessages/locale/ossn.tr.php
+++ b/components/OssnMessages/locale/ossn.tr.php
@@ -15,6 +15,9 @@ $tr = array(
     'ossn:message:between' => 'Mesaj %s',
     'messages' => 'Mesajlar',
     'message:placeholder' => 'Metninizi girin',
-    'no:messages' => 'Mesajınız yok.'
+    'no:messages' => 'Mesajınız yok.',
+	'delete:message' => 'Mesajı sil',
+	'delete:all:messages' => 'Tum mesajları sil',
+	'confirm:delete:messages' =>'Bu, bu listedeki tum iletileri silecektir. Devam etmek istiyor musunuz?'	
 );
 ossn_register_languages('tr', $tr); 

--- a/components/OssnMessages/ossn_com.php
+++ b/components/OssnMessages/ossn_com.php
@@ -138,6 +138,12 @@ function ossn_messages_page($pages) {
 						$params['recent'] = $OssnMessages->recentChat(ossn_loggedin_user()->guid);
 						echo ossn_plugin_view('messages/templates/message-with', $params);
 						break;
+				
+				case 'deletemessage':
+						$id = $pages[1];
+						$delete = $OssnMessages->deleteMessage($id);
+						break;
+				
 				default:
 						ossn_error_page();
 						break;

--- a/components/OssnMessages/ossn_com.php
+++ b/components/OssnMessages/ossn_com.php
@@ -124,6 +124,7 @@ function ossn_messages_page($pages) {
 						if($messages) {
 								foreach($messages as $message) {
 										$user              = ossn_user_by_guid($message->message_from);
+										$params['message_id']=$message->id;
 										$message           = $message->message;
 										$params['user']    = $user;
 										$params['message'] = $message;
@@ -142,7 +143,22 @@ function ossn_messages_page($pages) {
 				case 'deletemessage':
 						$id = $pages[1];
 						$delete = $OssnMessages->deleteMessage($id);
+						echo $delete;
 						break;
+						
+				case 'fromlist':
+					$from = $pages[1];
+					$list=$from;
+					$items=$OssnMessages->fromList($from);
+					if ($items){?>
+						<ul style="display:none !important;">
+						<?php foreach($items as $i=>$item){?>
+							<li data-id="<?php echo $item->id;?>" data-viewed="<?php echo $item->viewed;?>"><?php echo $item->id;?></li>
+						<?php } ?>
+						</ul>
+					<?php }
+					break;
+						
 				
 				default:
 						ossn_error_page();

--- a/components/OssnMessages/plugins/default/css/message.php
+++ b/components/OssnMessages/plugins/default/css/message.php
@@ -206,19 +206,43 @@
     vertical-align: top;
     margin: 10px 0px;
     border-color: #cdecb0;
-	position:relative;
 }
 
 .messages-with .widget-contents {
     padding: 10px 0px;
 }
 
+.widget-contents .message-with{
+	position: relative;
+}
+
+.ossn-widget.messages-with .widget-heading{
+	position:relative;
+}
+.ossn-widget.messages-with .widget-heading a.messages-action {
+	position:absolute;
+	z-index:1;
+	right:0;
+	bottom:0px;
+	width:20px;
+	display:none;
+	opacity:.15;
+}
+.ossn-widget.messages-with .widget-heading:hover a.messages-action{ display:block;}
+
+
+.message-box-recieved a.message-action,
 .message-box-sent a.message-action{
 	position:absolute;
-	right:0;
+	left:3px;
 	bottom:0;
 	display:none;
 	opacity:.15;
 }
+.message-box-sent a.message-action{
+	left:auto;
+	right:0;
+}
 
+.message-box-recieved:hover a.message-action,
 .message-box-sent:hover a.message-action{ display:block;}

--- a/components/OssnMessages/plugins/default/css/message.php
+++ b/components/OssnMessages/plugins/default/css/message.php
@@ -211,3 +211,13 @@
 .messages-with .widget-contents {
     padding: 10px 0px;
 }
+
+.message-box-sent a.message-action{
+	position:absolute;
+	right:0;
+	bottom:0;
+	display:none;
+	opacity:.15;
+}
+
+.message-box-sent:hover a.message-action{ display:block;}

--- a/components/OssnMessages/plugins/default/css/message.php
+++ b/components/OssnMessages/plugins/default/css/message.php
@@ -206,6 +206,7 @@
     vertical-align: top;
     margin: 10px 0px;
     border-color: #cdecb0;
+	position:relative;
 }
 
 .messages-with .widget-contents {

--- a/components/OssnMessages/plugins/default/js/OssnMessages.php
+++ b/components/OssnMessages/plugins/default/js/OssnMessages.php
@@ -70,41 +70,82 @@ Ossn.deleteMessage = function($guid, $id) {
         action: false,
         callback: function(callback) {
             if(callback){
-				$('#message-append-' + $guid).find('#ossn-message-item-'+$id).closest('div.row').remove();
-				$('#ossn-chat-messages-data-' + $guid).find('#ossn-message-item-'+$id).remove();
+				$('#message-append-' + $guid).find('#ossn-message-item-'+$id).closest('div.row').hide(300,
+					function(){
+						this.remove();
+					});
+				$('#ossn-chat-messages-data-' + $guid).find('#ossn-message-item-'+$id).hide(300,
+					function(){
+						this.remove();
+					});
             }
         }
     });
 	return true;
 };
 
-
-Ossn.refreshList = function($from,$count) {
+Ossn.refreshList = function($from) {
     Ossn.PostRequest({
-        url: Ossn.site_url + "messages/fromlist/" + $from,
+        url: Ossn.site_url + "messages/getlist/" + $from,
         action: false,
-        callback: function(callback) {
-			$('#message-list').html(callback);
-            if(callback){
-				var list=$("#message-list ul li").size();
-				var onlist=$("#message-append-"+$from+" .message-box-recieved").size();
-				if (list!=onlist){
-					var id=0;
-					list=[];
-					$("#message-list ul li").each(function(index, item){
-						id=$(item).attr('data-id');
-						list[index]=id;
-					});
-					$("#message-append-"+$from+" .message-box-recieved").each(function(index, item){
-						id=$(item).attr('data-id');
-						if ( (id>0) && ($.inArray(id,list)===-1) ){
-							$('#message-append-' + $from).find('#ossn-message-item-'+id).closest('div.row').remove();
-							$('#ossn-chat-messages-data-' + $from).find('#ossn-message-item-'+id).remove();
-						}
-					});
+        callback: function(list) {
+			if (list){
+				var list=$.parseJSON(list);
+			}
+			$(list).each(function(i,vals){
+				var key=Object.keys(vals)[0];
+				if (( key=="hidden") && (vals.hidden) ){
+					Ossn.hiddenList(vals.hidden,$from);
 				}
-            }
+				if (( key=="archive") && (vals.archive) ){
+					Ossn.archiveList(vals.archive,$from);
+				}
+				if (( key=="spam") && (vals.spam) ){
+					Ossn.spamList(vals.spam,$from);
+				}
+				if (( key=="block") && (vals.block) ){
+					Ossn.blockList(vals.block,$from);
+				}
+			});
         }
     });
 	return true;
 };
+
+Ossn.hiddenList = function(items,$from) {
+	if (items.length>0){
+		var id=0;
+		var status=0;
+		var hide=0;
+		$(items).each(function(index, item){
+			item=$.parseJSON(item);
+			id=item.id;
+			status=item.status;
+			hide=((status==1) || (status>2));
+			if (hide){
+				$('#message-append-' + $from).find('#ossn-message-item-'+id).closest('div.row').hide(300,
+					function(){
+						this.remove();
+					});
+				$('#ossn-chat-messages-data-' + $from).find('#ossn-message-item-'+id).hide(300,
+					function(){
+						this.remove();
+					});
+			}
+		});
+	}
+}
+Ossn.archiveList = function(list,$from) {
+	//implement codes here
+}
+Ossn.spamList = function(list,$from) {
+	//spam list are also hidden
+	Ossn.hiddenList(list,$from);
+	//implement other codes here
+}
+Ossn.blockList = function(list,$from) {
+	//block list are also hidden
+	Ossn.hiddenList(list,$from);
+	//implement other codes here
+}
+

--- a/components/OssnMessages/plugins/default/js/OssnMessages.php
+++ b/components/OssnMessages/plugins/default/js/OssnMessages.php
@@ -69,10 +69,40 @@ Ossn.deleteMessage = function($guid, $id) {
         url: Ossn.site_url + "messages/deletemessage/" + $id,
         action: false,
         callback: function(callback) {
-			$('#message-append-' + $guid).find('#message-'+$id).closest('div.row').remove();
             if(callback){
-            	//Unwanted refresh in message window #416 , there is no need to scroll if no new message.
-	            Ossn.message_scrollMove($guid);
+				$('#message-append-' + $guid).find('#ossn-message-item-'+$id).closest('div.row').remove();
+				$('#ossn-chat-messages-data-' + $guid).find('#ossn-message-item-'+$id).remove();
+            }
+        }
+    });
+	return true;
+};
+
+
+Ossn.refreshList = function($from,$count) {
+    Ossn.PostRequest({
+        url: Ossn.site_url + "messages/fromlist/" + $from,
+        action: false,
+        callback: function(callback) {
+			$('#message-list').html(callback);
+            if(callback){
+				var list=$("#message-list ul li").size();
+				var onlist=$("#message-append-"+$from+" .message-box-recieved").size();
+				if (list!=onlist){
+					var id=0;
+					list=[];
+					$("#message-list ul li").each(function(index, item){
+						id=$(item).attr('data-id');
+						list[index]=id;
+					});
+					$("#message-append-"+$from+" .message-box-recieved").each(function(index, item){
+						id=$(item).attr('data-id');
+						if ( (id>0) && ($.inArray(id,list)===-1) ){
+							$('#message-append-' + $from).find('#ossn-message-item-'+id).closest('div.row').remove();
+							$('#ossn-chat-messages-data-' + $from).find('#ossn-message-item-'+id).remove();
+						}
+					});
+				}
             }
         }
     });

--- a/components/OssnMessages/plugins/default/js/OssnMessages.php
+++ b/components/OssnMessages/plugins/default/js/OssnMessages.php
@@ -63,3 +63,18 @@ Ossn.message_scrollMove = function(fid) {
         return message.scrollTop;
     }
 };
+
+Ossn.deleteMessage = function($guid, $id) {
+    Ossn.PostRequest({
+        url: Ossn.site_url + "messages/deletemessage/" + $id,
+        action: false,
+        callback: function(callback) {
+			$('#message-append-' + $guid).find('#message-'+$id).closest('div.row').remove();
+            if(callback){
+            	//Unwanted refresh in message window #416 , there is no need to scroll if no new message.
+	            Ossn.message_scrollMove($guid);
+            }
+        }
+    });
+	return true;
+};

--- a/components/OssnMessages/plugins/default/messages/pages/view/with.php
+++ b/components/OssnMessages/plugins/default/messages/pages/view/with.php
@@ -1,22 +1,35 @@
 <script>
     Ossn.SendMessage(<?php echo $params['user']->guid;?>);
-            $(document).ready(function () {
-                setInterval(function () {
-                    Ossn.getMessages('<?php echo $params['user']->username;?>', '<?php echo $params['user']->guid;?>');
-					Ossn.refreshList('<?php echo $params['user']->guid;?>');
-                    //Ossn.getRecent('<?php echo $params['user']->guid;?>');
-                }, 5000);
-               	Ossn.message_scrollMove(<?php echo $params['user']->guid;?>);
+	$(document).ready(function () {
+		setInterval(function () {
+            Ossn.getMessages('<?php echo $params['user']->username;?>', '<?php echo $params['user']->guid;?>');
+			Ossn.refreshList('<?php echo $params['user']->guid;?>');
+            //Ossn.getRecent('<?php echo $params['user']->guid;?>');
+        }, 5000);
+        Ossn.message_scrollMove(<?php echo $params['user']->guid;?>);
 
-				$("#message-append-<?php echo $params['user']->guid;?>").on("click",".message-action", function(){
-				var id=$(this).closest(".message-box-sent").attr('data-id');
-				Ossn.deleteMessage('<?php echo $params['user']->guid;?>', id);
-			});
+		$("#message-append-<?php echo $params['user']->guid;?>").on("click",".message-action", function(){
+			var id=$(this).closest("div.text").attr('data-id');
+			Ossn.deleteMessage('<?php echo $params['user']->guid;?>', id);
+		});
+		
+		$(".ossn-widget.messages-with .widget-heading").append(
+			'<a href="#" title="<?php echo ossn_print('delete:all:messages'); ?>" class="messages-action"><i class="fa fa-times"></i></a>'
+		);
+		$(".ossn-widget.messages-with .widget-heading").on("click",".messages-action", function(){
+			if (confirm("<?php echo ossn_print('confirm:Delete:messages'); ?>")){
+				$("#message-append-<?php echo $params['user']->guid; ?> .message-action").each(function(i,data){
+					$(data).trigger("click");
+				});
+			}
+		});
+
+		
+
     });
 	  
 </script>
 <div class="message-with">
-<div id="message-list"></div>
 
 <div class="message-inner" id="message-append-<?php echo $params['user']->guid; ?>">
 <?php
@@ -27,7 +40,7 @@ if ($params['data']) {
 					?>
                     	<div class="row">
                                 <div class="col-md-10">
-                                		<div class="message-box-sent text" style="position:relative;" id="ossn-message-item-<?php echo $message->id;?>" data-id="<?php echo $message->id;?>">
+                                		<div class="message-box-sent text" id="ossn-message-item-<?php echo $message->id;?>" data-id="<?php echo $message->id;?>">
                                 			<?php
                                					 if (function_exists('smilify')) {
                                 					    echo smilify(ossn_message_print($message->message));
@@ -36,7 +49,7 @@ if ($params['data']) {
                             					    }
 
                               				?>
-											<a href="#" title="Delete Message" class="message-action"><i class="fa fa-times"></i></a>
+											<a href="#" title="<?php echo ossn_print('delete:message'); ?>" class="message-action"><i class="fa fa-times"></i></a>
                                         <div class="time-created"><?php echo ossn_user_friendly_time($message->time);?></div>    
                                         </div>
                                 </div>
@@ -60,6 +73,7 @@ if ($params['data']) {
                                 					    echo ossn_message_print($message->message);
                             					    }
                               				?>
+											<a href="#" title="Delete Message" class="message-action"><i class="fa fa-times"></i></a>
                                         <div class="time-created"><?php echo ossn_user_friendly_time($message->time);?></div>                                                
                                         </div>
                                 </div>

--- a/components/OssnMessages/plugins/default/messages/pages/view/with.php
+++ b/components/OssnMessages/plugins/default/messages/pages/view/with.php
@@ -7,9 +7,9 @@
                 }, 5000);
                	Ossn.message_scrollMove(<?php echo $params['user']->guid;?>);
 		    
-		$(".message-action").click(function(){
-		    var id=$(this).attr('data-id');
-		    Ossn.deleteMessage('<?php echo $params['user']->guid;?>', id);
+		$("#message-append-<?php echo $params['user']->guid;?>").on("click",".message-action", function(){
+			var id=$(this).attr('data-id');
+			Ossn.deleteMessage('<?php echo $params['user']->guid;?>', id);
 		});
 		    
       });

--- a/components/OssnMessages/plugins/default/messages/pages/view/with.php
+++ b/components/OssnMessages/plugins/default/messages/pages/view/with.php
@@ -6,6 +6,12 @@
                     //Ossn.getRecent('<?php echo $params['user']->guid;?>');
                 }, 5000);
                	Ossn.message_scrollMove(<?php echo $params['user']->guid;?>);
+		    
+		$(".message-action").click(function(){
+		    var id=$(this).attr('data-id');
+		    Ossn.deleteMessage('<?php echo $params['user']->guid;?>', id);
+		});
+		    
       });
 </script>
 <div class="message-with">
@@ -25,7 +31,8 @@ if ($params['data']) {
                              					   } else {
                                 					    echo ossn_message_print($message->message);
                             					    }
-                              				?>
+                             				?>
+					<a id="message-<?php echo $message->id;?>" class="message-action" data-id="<?php echo $message->id;?>" href="#" title="Delete Message"><i class="fa fa-times"></i></a>
                                         <div class="time-created"><?php echo ossn_user_friendly_time($message->time);?></div>    
                                         </div>
                                 </div>

--- a/components/OssnMessages/plugins/default/messages/pages/view/with.php
+++ b/components/OssnMessages/plugins/default/messages/pages/view/with.php
@@ -3,18 +3,21 @@
             $(document).ready(function () {
                 setInterval(function () {
                     Ossn.getMessages('<?php echo $params['user']->username;?>', '<?php echo $params['user']->guid;?>');
+					Ossn.refreshList('<?php echo $params['user']->guid;?>');
                     //Ossn.getRecent('<?php echo $params['user']->guid;?>');
                 }, 5000);
                	Ossn.message_scrollMove(<?php echo $params['user']->guid;?>);
-		    
-		$("#message-append-<?php echo $params['user']->guid;?>").on("click",".message-action", function(){
-			var id=$(this).attr('data-id');
-			Ossn.deleteMessage('<?php echo $params['user']->guid;?>', id);
-		});
-		    
-      });
+
+				$("#message-append-<?php echo $params['user']->guid;?>").on("click",".message-action", function(){
+				var id=$(this).closest(".message-box-sent").attr('data-id');
+				Ossn.deleteMessage('<?php echo $params['user']->guid;?>', id);
+			});
+    });
+	  
 </script>
 <div class="message-with">
+<div id="message-list"></div>
+
 <div class="message-inner" id="message-append-<?php echo $params['user']->guid; ?>">
 <?php
 if ($params['data']) {
@@ -24,15 +27,16 @@ if ($params['data']) {
 					?>
                     	<div class="row">
                                 <div class="col-md-10">
-                                		<div class="message-box-sent text">
+                                		<div class="message-box-sent text" style="position:relative;" id="ossn-message-item-<?php echo $message->id;?>" data-id="<?php echo $message->id;?>">
                                 			<?php
                                					 if (function_exists('smilify')) {
                                 					    echo smilify(ossn_message_print($message->message));
                              					   } else {
                                 					    echo ossn_message_print($message->message);
                             					    }
-                             				?>
-					<a id="message-<?php echo $message->id;?>" class="message-action" data-id="<?php echo $message->id;?>" href="#" title="Delete Message"><i class="fa fa-times"></i></a>
+
+                              				?>
+											<a href="#" title="Delete Message" class="message-action"><i class="fa fa-times"></i></a>
                                         <div class="time-created"><?php echo ossn_user_friendly_time($message->time);?></div>    
                                         </div>
                                 </div>
@@ -48,7 +52,7 @@ if ($params['data']) {
                                 	<img  class="user-icon" src="<?php echo $user->iconURL()->small;?>" />
                                 </div>                                
                                 <div class="col-md-10">
-                                		<div class="message-box-recieved text">
+                                		<div class="message-box-recieved text" id="ossn-message-item-<?php echo $message->id;?>" data-id="<?php echo $message->id;?>">
                                 			<?php
                                					 if (function_exists('smilify')) {
                                 					    echo smilify(ossn_message_print($message->message));

--- a/components/OssnMessages/plugins/default/messages/templates/message-send.php
+++ b/components/OssnMessages/plugins/default/messages/templates/message-send.php
@@ -22,6 +22,7 @@ if($user->guid == ossn_loggedin_user()->guid){
                                 					    echo ossn_message_print($message);
                             					    }
                               				?>
+					    <a id="message-<?php echo $message->id;?>" class="message-action" data-id="<?php echo $message->id;?>" href="#" title="Delete Message"><i class="fa fa-times"></i></a>
                                             <div class="time-created"><?php echo ossn_user_friendly_time(time());?></div>
                                         </div>
                                 </div>

--- a/components/OssnMessages/plugins/default/messages/templates/message-send.php
+++ b/components/OssnMessages/plugins/default/messages/templates/message-send.php
@@ -10,11 +10,12 @@
  */
 $user = $params['user'];
 $message = ossn_message_print($params['message']);
+$message_id=$params['message_id'];
 if($user->guid == ossn_loggedin_user()->guid){
 					?>
                     	<div class="row">
                                 <div class="col-md-10">
-                                		<div class="message-box-sent text">
+                                		<div class="message-box-sent text" id="ossn-message-item-<?php echo $message_id;?>" data-id="<?php echo $message_id;?>" >
                                 			<?php
                                					 if (function_exists('smilify')) {
                                 					    echo smilify($message);
@@ -22,7 +23,7 @@ if($user->guid == ossn_loggedin_user()->guid){
                                 					    echo ossn_message_print($message);
                             					    }
                               				?>
-					    <a id="message-<?php echo $message->id;?>" class="message-action" data-id="<?php echo $message->id;?>" href="#" title="Delete Message"><i class="fa fa-times"></i></a>
+											<a href="#" title="Delete Message" class="message-action"><i class="fa fa-times"></i></a>
                                             <div class="time-created"><?php echo ossn_user_friendly_time(time());?></div>
                                         </div>
                                 </div>
@@ -38,7 +39,7 @@ if($user->guid == ossn_loggedin_user()->guid){
                                 	<a href="<?php echo $user->profileURL();?>"><img  class="user-icon" src="<?php echo $user->iconURL()->small;?>" /></a>
                                 </div>                                
                                 <div class="col-md-10">
-                                		<div class="message-box-recieved text">
+                                		<div class="message-box-recieved text" id="ossn-message-item-<?php echo $message_id;?>" data-id="<?php echo $message_id;?>" >
                                 			<?php
                                					 if (function_exists('smilify')) {
                                 					    echo smilify($message);

--- a/components/OssnMessages/plugins/default/messages/templates/message-send.php
+++ b/components/OssnMessages/plugins/default/messages/templates/message-send.php
@@ -23,7 +23,7 @@ if($user->guid == ossn_loggedin_user()->guid){
                                 					    echo ossn_message_print($message);
                             					    }
                               				?>
-											<a href="#" title="Delete Message" class="message-action"><i class="fa fa-times"></i></a>
+											<a href="#" title="<?php echo ossn_print('delete:message'); ?>" class="message-action"><i class="fa fa-times"></i></a>
                                             <div class="time-created"><?php echo ossn_user_friendly_time(time());?></div>
                                         </div>
                                 </div>
@@ -47,6 +47,7 @@ if($user->guid == ossn_loggedin_user()->guid){
                                 					    echo $message;
                             					    }
                               				?>
+										 <a href="#" title="<?php echo ossn_print('delete:message'); ?>" class="message-action"><i class="fa fa-times"></i></a>
                                          <div class="time-created"><?php echo ossn_user_friendly_time(time());?></div>    
                                         </div>
                                 </div>

--- a/installation/sql/opensource-socialnetwork.sql
+++ b/installation/sql/opensource-socialnetwork.sql
@@ -270,3 +270,7 @@ ALTER TABLE `ossn_users`
 	ADD FULLTEXT KEY `email` (`email`),
 	ADD FULLTEXT KEY `first_name` (`first_name`),
 	ADD FULLTEXT KEY `last_name` (`last_name`);
+	
+-- Added by homelancer 07/10/2017 for delete (hide) message and other actions
+ALTER TABLE `ossn_messages` 
+	ADD `status` VARCHAR(1) NOT NULL DEFAULT '0' AFTER `viewed`;	


### PR DESCRIPTION
On the 'See All Messages', when the user hovers on their own sent messages, an 'x' icon shows up with a tooltip that says 'Delete Message'. Clicking on the 'x' icon will remove the message from the messages table and remove it from the sender's chat view.

For now it does not automatically refresh on the bottom chat box and the recipient message list. 

Update: July 11, 2017
Updated the messages delete feature to only update the 'status' field and prevents it from being listed in the messages list of the users in the frontend. Delete message does not physically remove the messages from the database.

Both sender and recipient messages can be deleted and also allow deleting all messages on the current view of messages.

'status' field as varchar(1) must be added to ossn_messages table in the database.