### PR TITLE
added 'order_by' parm to ossn_get_relationships()

### DIFF
--- a/libraries/ossn.lib.relations.php
+++ b/libraries/ossn.lib.relations.php
@@ -169,7 +169,8 @@ function ossn_get_relationships(array $params = array()) {
 				$count           = array_merge($vars, $count);
 				return $database->select($count)->total;
 		}
-		
+
+		$vars['order_by'] = $options['order_by'];
 		$data = $database->select($vars, true);
 		if($data) {
 				return $data;


### PR DESCRIPTION
to achieve a way to get latest relations first

BTW: please verify line 164:  $vars['params']) has never been set, it's either obsolete or a typo and you wanted to unset something else