### PR TITLE
Force starting offset=1 in case no value is available via input()

### DIFF
--- a/classes/OssnPagination.php
+++ b/classes/OssnPagination.php
@@ -119,7 +119,7 @@ class OssnPagination {
 						return false;
 				}
 				if(!empty($vars)) {
-						$vars['offset'] = (int) input('offset');
+						$vars['offset'] = (int) input('offset') ? (int) input('offset') : 1;
 						$vars['total']  = abs($vars['limit'] / $vars['page_limit']);
 						$vars['total']  = (int) ceil($vars['total']);
 						return $this->view($vars);


### PR DESCRIPTION
1. we achieve a properly highlighted 'Page1' pagination tab on initial page load this way
2. this is a pre-requiste for upcoming auto-pagination