### PR TITLE
add writable check to composants folder at installation

### DIFF
--- a/installation/classes/OssnInstall.php
+++ b/installation/classes/OssnInstall.php
@@ -133,6 +133,22 @@ class OssnInstallation {
 		}
 		
 		/**
+		 * Check if components directory is writeable or not
+		 *
+		 * @last edit: $Salbei
+		 * @Reason: Initial;
+		 * @return bool;
+		 */
+		public static function isComp_WRITEABLE() {
+				$path = str_replace('installation/', '', ossn_installation_paths()->root);
+				$path = $path . 'components';
+				if(is_dir($path) && is_writable($path)) {
+						return true;
+				}
+				return false;
+		}
+		
+		/**
 		 * Check if mysqli class exist exist or not
 		 *
 		 * @last edit: $arsalanshah

--- a/installation/locales/ossn.en.php
+++ b/installation/locales/ossn.en.php
@@ -60,6 +60,9 @@ $englsih = array(
 	'ossn:install:config' => 'CONFIGURATION DIRECTORY WRITEABLE',
 	'ossn:install:config:error' => 'CONFIGURATION DIRECTORY IS NOT WRITEABLE',
 	
+	'ossn:install:components' => 'COMPONENTS DIRECTORY WRITEABLE',
+	'ossn:install:components:error' => 'COMPONENTS DIRECTORY IS NOT WRITEABLE',
+	
 	'ossn:install:next' => 'Next',
     'ossn:install:install' => 'Install',
     'ossn:install:create' => 'Create',

--- a/installation/locales/ossn.fr.php
+++ b/installation/locales/ossn.fr.php
@@ -58,7 +58,10 @@ $fr = array(
 	'ossn:install:gd:required' => 'LIBRAIRIE PHP GD REQUISE',
 	
 	'ossn:install:config' => 'REPERTOIRE DE CONFIGURATION ACCESSIBLE EN ECRITURE',
-	'ossn:install:config:error' => 'LE REPERTOIRE DE CONFIGURATION N\'EST ACCESSIBLE EN ECRITURE',
+	'ossn:install:config:error' => 'LE REPERTOIRE DE CONFIGURATION N\'EST PAS ACCESSIBLE EN ECRITURE',
+	
+	'ossn:install:components' => 'REPERTOIRE DES COMPOSANTS ACCESSIBLE EN ECRITURE',
+	'ossn:install:components:error' => 'LE REPERTOIRE DES COMPOSANTS N\'EST PAS ACCESSIBLE EN ECRITURE',
 	
 	'ossn:install:next' => 'Suivant',
     'ossn:install:install' => 'Installer',

--- a/installation/pages/check.php
+++ b/installation/pages/check.php
@@ -53,6 +53,12 @@ if (OssnInstallation::isCon_WRITEABLE()) {
     echo '<div class="ossn-installation-message ossn-installation-fail">'.ossn_installation_print('ossn:install:config:error').'</div>';
     $error[] = 'permission:configuration';
 }
+if (OssnInstallation::isComp_WRITEABLE()) {
+    echo '<div class="ossn-installation-message ossn-installation-success">'.ossn_installation_print('ossn:install:components').'</div>';
+} else {
+    echo '<div class="ossn-installation-message ossn-installation-fail">'.ossn_installation_print('ossn:install:components:error').'</div>';
+    $error[] = 'permission:components';
+}
 if(OssnInstallation::allowUrlFopen()){
     echo '<div class="ossn-installation-message ossn-installation-success">'.ossn_installation_print('ossn:install:allowfopenurl').'</div>';	
 } else {


### PR DESCRIPTION
added because the error message when installing a component is not explicit: "Cannot upload component, make sure it is a valid package."
Maybe we can just improve the isCon_WRITEABLE function to check all writable folders because I thin themes folder is aslo concerned.
It's up to you.