### PR TITLE
removed explicit script type specification

### DIFF
--- a/libraries/ossn.lib.javascripts.php
+++ b/libraries/ossn.lib.javascripts.php
@@ -147,9 +147,7 @@ function ossn_html_js($args) {
 	if(!is_array($args)){
 		return false;
 	}
-	$default = array(
-					 'type' => 'text/javascript',
-					 );	
+	$default = array();	
 	$args = array_merge($default, $args);
     $extend = ossn_args($args);
     return "\r\n<script {$extend}></script>";


### PR DESCRIPTION
According to https://validator.w3.org/nu/ this is not necessary