### PR TITLE
fix html validation error because of unallowed child element

### DIFF
--- a/themes/goblue/plugins/default/theme/page/elements/topbar.php
+++ b/themes/goblue/plugins/default/theme/page/elements/topbar.php
@@ -21,6 +21,7 @@
 			</div>
 			<div class="col-md-3 text-right right-side">
 				<div class="topbar-menu-right">
+					<ul>
 					<li class="ossn-topbar-dropdown-menu">
 						<div class="dropdown">
 						<?php
@@ -41,6 +42,7 @@
 							echo ossn_plugin_view('notifications/page/topbar');
 						}
 						?>
+					</ul>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
According to https://validator.w3.org/nu/ a <li> must not be a child of a <div>