### PR TITLE
simplified condition

### DIFF
--- a/components/OssnNotifications/ossn_com.php
+++ b/components/OssnNotifications/ossn_com.php
@@ -169,7 +169,7 @@ function ossn_notification_page($pages) {
 						}
 						$friends   = ossn_loggedin_user()->getFriendRequests();
 						$friends_c = 0;
-						if(count($friends) > 0 && !empty($friends)) {
+						if($friends) {
 								$friends_c = count($friends);
 						}
 						echo json_encode(array(


### PR DESCRIPTION
php 7.2 throws a warning here
and since getFriendRequests() either returns false or an array, the sequence of the old condition didn't make too much sense anyway :)