### PR TITLE
fix for php 7.2 warning + call plugin_view only if necessary

### DIFF
--- a/components/OssnNotifications/ossn_com.php
+++ b/components/OssnNotifications/ossn_com.php
@@ -107,8 +107,7 @@ function ossn_notification_page($pages) {
 						break;
 				case 'friends':
 						$friends['friends'] = ossn_loggedin_user()->getFriendRequests();
-						$friends_count      = count($friends['friends']);
-						if($friends_count > 0 && !empty($friends['friends'])) {
+						if(!empty($friends['friends'])) {
 								$data = ossn_plugin_view('notifications/pages/notification/friends', $friends);
 								echo json_encode(array(
 										'type' => 1,
@@ -125,8 +124,8 @@ function ossn_notification_page($pages) {
 				case 'messages':
 						$OssnMessages     = new OssnMessages;
 						$params['recent'] = $OssnMessages->recentChat(ossn_loggedin_user()->guid);
-						$data             = ossn_plugin_view('messages/templates/message-with-notifi', $params);
 						if(!empty($params['recent'])) {
+								$data = ossn_plugin_view('messages/templates/message-with-notifi', $params);
 								echo json_encode(array(
 										'type' => 1,
 										'data' => $data


### PR DESCRIPTION
PHP WARNING: 2018-10-23 10:46:29 (BST): "count(): Parameter must be an array or an object that implements Countable" in file /components/OssnNotifications/ossn_com.php (line 111)