### PR TITLE
fix recentChat query

### DIFF
--- a/components/OssnMessages/classes/OssnMessages.php
+++ b/components/OssnMessages/classes/OssnMessages.php
@@ -129,7 +129,7 @@ class OssnMessages extends OssnEntities {
 								"m2.id IS NULL AND m.message_to = '{$to}' AND m.message != ''"
 						),
 						'joins' => array(
-								"LEFT JOIN ossn_messages m2 ON (m.message_from = m2.message_from AND m.id < m2.id AND m2.message != '')"
+								"LEFT JOIN ossn_messages m2 ON m.message_from = m2.message_from AND m.message_to = m2.message_to AND m.id < m2.id"
 						),
 						'offset' => input('offset_message_xhr_recent', '', 1),
 						'count'  => $count


### PR DESCRIPTION
While extensive testing I became aware that my former query wasn't quite ok:
It was working correctly for the latest 2 chat partners, but other users didn't see their conversations anymore.
I verified new query again with 5 different users, and the changed query returns correct results now.
Sorry.