### PR TITLE
make left/right cover repositioning work in groups

### DIFF
--- a/components/OssnGroups/plugins/default/css/groups.php
+++ b/components/OssnGroups/plugins/default/css/groups.php
@@ -191,7 +191,6 @@
     height: 200px;
 }
 .ossn-group-cover img {
-	width:100%;
     position:relative;
 }
 .ossn-group-cover:hover > .ossn-group-cover-button {


### PR DESCRIPTION
with image width set to 100% the image will get the same width as surrounding cover container,
so maxWidth: $("#draggable").width() - $("#container").width() on line 87 of in groups javascript will be always 0
resulting in newLeft=0, too some lines below