### PR TITLE
removed wrong attribute from textarea tag

### DIFF
--- a/system/plugins/default/input/textarea.php
+++ b/system/plugins/default/input/textarea.php
@@ -14,6 +14,7 @@ if(isset($params['class'])){
 	$class = $class . $params['class'];
 }
 $value = (isset($params['value'])) ? $params['value'] : '';
+unset ($params['value']);
 
 $defaults = array(
 	'disabled' => false,


### PR DESCRIPTION
html <textarea> has no such attribute named 'value'
(obviously it didn't seem to hurt in the past, but with longer content it results in really unnecessary additional pageload)