### PR TITLE
getting orphan like records on annotation bulk delete

### DIFF
--- a/classes/OssnAnnotation.php
+++ b/classes/OssnAnnotation.php
@@ -173,7 +173,9 @@ class OssnAnnotation extends OssnEntities {
 				$this->page_limit   = false;
 				$annotations        = $this->getAnnotationBySubject();
 				if($annotations) {
+						$like = new OssnLikes;
 						foreach($annotations as $annontation) {
+								$like->deleteLikes($annontation->id, 'annotation');
 								$this->deleteAnnotation($annontation->id);
 						}
 						return true;


### PR DESCRIPTION
steps to reproduce:
1. upload a new photo to your album
2. comment that photo
3. like the comment (not the photo!)
4. delete the photo
=> like record still in place

this fix basically solves the problem ... but maybe you prefer different way ... class check if OssnLikes exists could not be wrong, too