### PR TITLE
use same version requirement logic as with components

### DIFF
--- a/classes/OssnThemes.php
+++ b/classes/OssnThemes.php
@@ -225,7 +225,7 @@ class OssnThemes extends OssnSite {
 												$requirments['type']         = ossn_print('ossn:version');
 												$requirments['value']        = (string) $item->version;
 												$requirments['availability'] = 0;
-												$site_version                = (int) ossn_site_settings('site_version');
+												$site_version                = ossn_site_settings('site_version');
 												
 												//Ossn Version checking not strict enough when installing components #1000
 												$comparator = '>=';


### PR DESCRIPTION
sorry, overlooked that in #1371 

that is: someone who wants to restrict a theme to Ossn 5.0, currently (and before this fix is part of 5.1) the theme must be marked with just '5' - no minor version (.0). Otherwise comparison will fail