### PR TITLE
add required field to message textarea (issue 1427)

### DIFF
--- a/components/OssnMessages/plugins/default/forms/OssnMessages/send.php
+++ b/components/OssnMessages/plugins/default/forms/OssnMessages/send.php
@@ -1,4 +1,4 @@
-                <textarea name="message" placeholder="<?php echo ossn_print('message:placeholder'); ?>"></textarea>
+                <textarea name="message" placeholder="<?php echo ossn_print('message:placeholder'); ?>" required></textarea>
                 <input type="hidden" name="to" value="<?php echo $params['user']->guid; ?>"/>
 
                 <div class="controls">


### PR DESCRIPTION
fixes the issue described in issue 1427. Without this fix, when clicking "Send" on the messages page while leaving the 'message' textarea blank, it will append a 0 to the message window each time Send is clicked. See issue #1427 for screenshot (also attached here).
![ossn_messages_page_bug](https://user-images.githubusercontent.com/5515614/50085486-c8c13f80-01bf-11e9-93b7-ace85d47496c.jpg)
