### PR TITLE
hide Group page right sidebar on mobile devices

### DIFF
--- a/components/OssnGroups/plugins/default/groups/pages/profile.php
+++ b/components/OssnGroups/plugins/default/groups/pages/profile.php
@@ -161,11 +161,11 @@ $members = $params['group']->getMembers();
             </div>
         </div>
         <div class="col-md-4 margin-top-10">
-        	<div class="page-sidebar">
+        	<div class="page-sidebar hidden-xs">
         	<?php 
 			echo ossn_view_widget(array(
 								'title' => ossn_print('about:group'),
-								'contents' => $params['group']->description,
+								'contents' => nl2br($params['group']->description),
 								'class' => 'widget-description',
 			));					
 			if ($params['group']->owner_guid == ossn_loggedin_user()->guid || ossn_isAdminLoggedin()) {


### PR DESCRIPTION
otherwise it will appear below the last posting and it will become cumbersome with Autopagination to reach new join requests
+ show newlines in Group About section