### PR TITLE
fixed wrong logic sequence

### DIFF
--- a/components/OssnNotifications/classes/OssnNotifications.php
+++ b/components/OssnNotifications/classes/OssnNotifications.php
@@ -58,13 +58,13 @@ class OssnNotifications extends OssnDatabase {
 						if(!$this->notification) {
 								return false;
 						}
-						//check if owner_guid is empty or owner_guid is same as poster_guid then return false, 
-						if(empty($this->notification['owner_guid']) || $this->notification['owner_guid'] == $this->notification['poster_guid']) {
-								return false;
-						}
 						//check if notification owner is set then use it.
 						if(!empty($this->notification['notification_owner'])) {
 								$this->notification['owner_guid'] = $this->notification['notification_owner'];
+						}
+						//check if owner_guid is empty or owner_guid is same as poster_guid then return false, 
+						if(empty($this->notification['owner_guid']) || $this->notification['owner_guid'] == $this->notification['poster_guid']) {
+								return false;
 						}
 						$callback = array(
 								'type' => $this->notification['type'],


### PR DESCRIPTION
(with former logic, notification['notification_owner'] would be never used if notification['owner_guid'] is not set. On the other hand: If notification['owner_guid'] HAS BEEN SET in the hook, it makes no sense to replace afterwards by notification['notification_owner'] )