### PR TITLE
Confirmed friendship needs to be based on the existance of a '1 to 2' AND a '2 to 1' relation

### DIFF
--- a/classes/OssnUser.php
+++ b/classes/OssnUser.php
@@ -345,7 +345,7 @@ class OssnUser extends OssnEntities {
 		 * @return boolean
 		 */
 		public function isFriend($usera, $user2) {
-				return ossn_relation_exists($usera, $user2, 'friend:request');
+				return ossn_relation_exists($usera, $user2, 'friend:request') & ossn_relation_exists($user2, $usera, 'friend:request');
 		}
 		
 		/**


### PR DESCRIPTION
Example of issue with old code:
1 has sent a friend request to 2
request is still pending and unconfirmed by 2, but 1 can already post on 2's wall