### PR TITLE
Prevent overwriting of already installed components

### DIFF
--- a/classes/OssnComponents.php
+++ b/classes/OssnComponents.php
@@ -93,7 +93,7 @@ class OssnComponents extends OssnDatabase {
 										//need to check id , since ossn v3.x
 										if(isset($ossn_com_xml->id) && !empty($ossn_com_xml->id)) {
 												//move to components directory
-												if(OssnFile::moveFiles($files, ossn_route()->com . $ossn_com_xml->id . '/')) {
+												if((!is_dir(ossn_route()->com . $ossn_com_xml->id)) && (OssnFile::moveFiles($files, ossn_route()->com . $ossn_com_xml->id . '/'))) {
 														//add new component to system
 														$this->newCom($ossn_com_xml->id);
 														


### PR DESCRIPTION
see issue #1447 

BTW it's worth to have a look into moveFiles(), too
and return false and remove the tmp dir in case renaming fails
(I remember long time ago we had someone with a data dir mounted on a different filesystem, and renaming failed. To make things 100% perfect rename needs to be replaced by a recursive copy here :) )