### PR TITLE
don't remove query from search menu if it includes a whitepace

### DIFF
--- a/classes/OssnPagination.php
+++ b/classes/OssnPagination.php
@@ -37,7 +37,7 @@ class OssnPagination {
 				if(count($_GET)) {
 						$args_url = '';
 						foreach($_GET as $key => $value) {
-								if(!ctype_alnum($value) || in_array($key, $unset)) {
+								if(!preg_match('/^[a-zA-Z0-9 _]+$/', $value) || in_array($key, $unset)) {
 										continue;
 								}
 								//validate input again


### PR DESCRIPTION
don't remove query strings like "frosty flakes" from search menu (allow whitepace)
allow usage of underscore, too for better readable search types like 'type=my_custom_search'