### PR TITLE
return existing object unconditionally (= independant of current page…

### DIFF
--- a/libraries/ossn.lib.objects.php
+++ b/libraries/ossn.lib.objects.php
@@ -21,6 +21,7 @@ function ossn_get_object($guid){
 		$object = new OssnObject;
 		$search = $object->searchObject(array(
 			'wheres'=> "o.guid='{$guid}'",
+			'offset' => 1
 		));
 		if($search && isset($search[0]->guid)){
 			return $search[0];


### PR DESCRIPTION
… offset)

searchObject() needs to be forced to build the query like 'LIMIT 0, 10' on _all_ pages
old code would give 'LIMIT 10, 10' on page 2, thus an existing record will not be returned even if the guid is existing