### PR TITLE
Allow changing of group owner

### DIFF
--- a/components/OssnGroups/plugins/default/css/groups.php
+++ b/components/OssnGroups/plugins/default/css/groups.php
@@ -252,7 +252,6 @@
     text-transform: uppercase;
 }
 .ossn-group-members .request-controls {
-	margin-top:20px;
 }
 .ossn-group-members .request-controls a {
 	margin-left:5px;
@@ -279,4 +278,11 @@
 }
 .group-search-details .ossn-group-search-by a {
     margin-left: 5px;
+}
+@media only screen and (max-width: 767px) {
+	.btn-responsive {
+		padding:4px 9px;
+		font-size:90%;
+		line-height: 1.2;
+	}
 }


### PR DESCRIPTION
1. Removed margin-top of 'Remove' and 'Make group owner' buttons because they will appear on their own line now (see groups/pages/members.php)
2. Added new style for shrinking 'Remove' and 'Make group owner' buttons on mobile devices

Maybe the second change should be better made be available template-wide because this can be useful in other parts, too?!