### PR TITLE
route db connection failure error messages to Ossn 'error_log' file

### DIFF
--- a/classes/OssnDatabase.php
+++ b/classes/OssnDatabase.php
@@ -35,7 +35,8 @@ class OssnDatabase extends OssnBase {
 				if(!$connect->connect_errno) {
 						return $connect;
 				} else {
-						return false;
+						error_log('Database connection failed with error: ' . $connect->connect_errno . "\n", 3, ossn_route()->www . 'error_log');
+						exit('Database connection failed');
 				}
 		}
 		/**


### PR DESCRIPTION
Since Ossn's own error handler isn't set up at this early stage, messages may be logged anywhere depending on the provider's setup.
Thus, instead of asking the sys-admin to find the right location (if that's possible at all on shared hosting), better route the message right into Ossn's own error_log file.
Aside from that the old returning 'false' doesn't make much sense, in fact we can't do anything else than exit here.