### PR TITLE
added option to display explicit time to ossn_user_friendly_time

### DIFF
--- a/libraries/ossn.lib.users.php
+++ b/libraries/ossn.lib.users.php
@@ -243,18 +243,20 @@ function update_last_activity() {
  * @return bool
  */
 function ossn_user_friendly_time($tm, $rcs = 0) {
+		$passedtime = ossn_print('site:timepassed:data');
+		$pds        = explode('|', $passedtime);
+		if(!$pds || $pds && count($pds) < 2) {
+			return;
+		}
+		if(count($pds) == 2) {
+			// Option 1: display explicit time and use formatting string
+			// using strftime, we can even get localized months
+			setlocale(LC_TIME, $pds[1]);
+			return strftime($pds[0], $tm);
+		}
+		// Option 2: display elapsed time (Ossn default)
 		$cur_tm     = time();
 		$dif        = $cur_tm - $tm;
-		// get language dependend items for display
-		$passedtime = ossn_print('site:timepassed:data');
-		// put them into array
-		// 0  = second
-		// 15 = decades
-		$pds        = explode('|', $passedtime);
-		
-		// BETTER DO explode ONLY ONCE on start and when language changes
-		// and get already prepared array from there
-		// don't know how and where to do this correctly ?!?
 		$lngh = array(
 				1,
 				60,


### PR DESCRIPTION
In fact a feature request because I was never so much happy with getting elapsed times displayed.
2 hours ago might be meaningful, but what is '1 year ago'? Was it January, February ... could be everything...

Thus my idea was to add an option to display the exact time instead - while being still compatible with Ossn old default.
So, if a site admin prefers to display the exact time instead of elapsed time, he can simply use the CustomStrings component to override the original language string like:
	`'site:timepassed:data' => '%e %h %G %H:%M|en_EN.UTF-8',`
and he would get a date like **4 Oct 2019 13:22**
So the new string is assembled from just 2 parts: `strftime formatting placeholders | locale`
that's all.
Available locales will be displayed using the shell command line with `'locale -a' `
On Ubuntu, missing locales may be installed like `'apt-get install language-pack-de'` (if you need German for example)