### PR TITLE
Getting syntax error on opening comment likers list

### DIFF
--- a/components/OssnComments/plugins/default/comments/templates/comment.php
+++ b/components/OssnComments/plugins/default/comments/templates/comment.php
@@ -101,8 +101,8 @@ if($datalikes  > 0){
 						echo ossn_plugin_view('output/url', array(
 										'href' => 'javascript:void(0);', 
 										'text' => $likes_total, 
-										'onclick' => "Ossn.ViewLikes({$params['annotation_id']}, 'annotation')",
-										'class' => "ossn-total-likes ossn-total-likes-{$params['annotation_id']}",
+										'onclick' => "Ossn.ViewLikes({$params['comment']['id']}, 'annotation')",
+										'class' => "ossn-total-likes ossn-total-likes-{$params['comment']['id']}",
 										'data-likes' => $datalikes,
 						));
 						?>


### PR DESCRIPTION
I'm getting a javascript syntax error here, because there is no 'annotation_id' in the params array. 
Maybe you forgot to set it up like that..., don't know ...
The only usable item I found was ['comment']['id']