### PR TITLE
display right sidebar content above newsfeed on mobile devices

### DIFF
--- a/themes/goblue/plugins/default/theme/page/layout/newsfeed.php
+++ b/themes/goblue/plugins/default/theme/page/layout/newsfeed.php
@@ -14,13 +14,20 @@ if(ossn_is_hook('newsfeed', "sidebar:right")) {
 	$newsfeed_right = ossn_call_hook('newsfeed', "sidebar:right", NULL, array());
 	$sidebar = implode('', $newsfeed_right);
 	$isempty = trim($sidebar);
-}  
+}
+if(ossn_is_hook('newsfeed', "center:top")) {
+	$newsfeed_center_top = ossn_call_hook('newsfeed', "center:top", NULL, array());
+	$newsfeed_center_top = implode('', $newsfeed_center_top);
+}
 ?>
 <div class="container">
 	<div class="row">
        	<?php echo ossn_plugin_view('theme/page/elements/system_messages'); ?>    
 		<div class="ossn-layout-newsfeed">
 			<div class="col-md-7">
+				<div class="newsfeed-middle-top">
+					<?php echo $newsfeed_center_top; ?>
+				</div>
 				<div class="newsfeed-middle">
 					<?php echo $params['content']; ?>
 				</div>


### PR DESCRIPTION
1. added hook 'newsfeed', 'center:top' to receive content 
(currently feeded by "ExtraContent" component, should be made an integral part of HtmlSidebar later, so we can remove the ExtraContent component)

2. added div 'newsfeed-middle-top' to display that content

Note: to keep Greetings always on top of newfeed and ABOVE of extra-content, I currently changed its javascript like

		if($('.newsfeed-middle-top').length && $('.newsfeed-middle-top').is(':visible')) {
			$(greetingsComponent).insertBefore('.newsfeed-middle-top');
		}
		else {
			$('.newsfeed-middle').prepend(greetingsComponent);
		}

Maybe we should add another hook/div for stuff like greetings which needs to be displayed always and indendent of screensize, instead of doing a jquery insert?!?