### PR TITLE
make saved drag position available for scaling calculation

### DIFF
--- a/components/OssnGroups/plugins/default/groups/pages/profile.php
+++ b/components/OssnGroups/plugins/default/groups/pages/profile.php
@@ -56,7 +56,7 @@ $members = $params['group']->getMembers();
                     </div>
                 <?php } ?>                        
                 <img id="draggable" src="<?php echo $params['group']->coverURL(); ?>"
-                     style='<?php echo $cover_top; ?><?php echo $cover_left; ?>'/>
+                     style='<?php echo $cover_top; ?><?php echo $cover_left; ?>' data-top='<?php echo $coverp[0]; ?>' data-left='<?php echo $coverp[1]; ?>'/>
             </div>
         <?php } ?>
 


### PR DESCRIPTION
(we can't rely on current style 'top' and 'left' as these values might have been already changed by a former scaling calculation, that's why we need to retrieve the original saved values again by the theme's javascript)