### PR TITLE
don't display cover images before scale/dragposition is known

### DIFF
--- a/themes/goblue/plugins/default/css/core/default.php
+++ b/themes/goblue/plugins/default/css/core/default.php
@@ -1281,6 +1281,7 @@ a {
 
 .ossn-profile .top-container .profile-cover img {
 	width: auto;
+	display: none;
 }
 
 .ossn-profile-row {
@@ -1491,6 +1492,7 @@ a {
 
 .ossn-group-cover img {
 	width: auto;
+	display: none;
 }
 
 /*****************************


### PR DESCRIPTION
to avoid flickering especially on larger images and when the position is very different from 0/0
the images will be faded in by theme's javascript after calculations are done