### PR TITLE
force newly uploaded cover images to 'display:inline'

### DIFF
--- a/components/OssnProfile/plugins/default/js/OssnProfile.php
+++ b/components/OssnProfile/plugins/default/js/OssnProfile.php
@@ -114,6 +114,7 @@ Ossn.RegisterStartupFunction(function() {
 								$imageurl = $('.profile-cover').find('img').attr('src') + '?' + $time;
 								$('.profile-cover').find('img').attr('src', $imageurl);
 								$('.profile-cover').find('img').attr('style', '');
+								$('.profile-cover').find('img').show();
 								$('.ossn-covers-uploading-annimation').remove();
 							},
 						});


### PR DESCRIPTION
(otherwise it won't display after uploading no more because the new style of cover images has been changed to display:none now to avoid flickering while scaling)