### PR TITLE
display ads on pages with offset > 1

### DIFF
--- a/components/OssnAds/plugins/default/ads/page/view.php
+++ b/components/OssnAds/plugins/default/ads/page/view.php
@@ -9,7 +9,11 @@
  * @link      https://www.opensource-socialnetwork.org/
  */
 $ads = new OssnAds;
-$ads = $ads->getAds();
+$ads = $ads->getAds(
+	array (
+		'offset' => 1
+	)
+);
 if ($ads) {
 	echo '<div class="ossn-ads">';
         foreach ($ads as $ad) {


### PR DESCRIPTION
since getAds() is using searchObject()
the current offset of our page will get involved
and we won't see no ads on page offsets > 1 and a total number of ads < 10 with the old code
that's why getAds() needs its own start offset=1 here, independant of the page we're on