### PR TITLE
include locales of themes

### DIFF
--- a/libraries/ossn.lib.languages.php
+++ b/libraries/ossn.lib.languages.php
@@ -382,8 +382,13 @@ function ossn_standard_language_codes() {
  *
  * @return void
  */
-function ossn_load_available_languages() {
-		$codes = ossn_standard_language_codes();
+function ossn_load_available_languages($language_selection = false) {
+		if(!$language_selection) {
+				$codes = ossn_standard_language_codes();
+		} else {
+				$codes = array();
+				$codes[] = $language_selection;
+		}
 		$path  = ossn_route();
 		
 		$components = new OssnComponents;

--- a/libraries/ossn.lib.languages.php
+++ b/libraries/ossn.lib.languages.php
@@ -387,7 +387,8 @@ function ossn_load_available_languages() {
 		$path  = ossn_route();
 		
 		$components = new OssnComponents;
-		
+		$themes = new OssnThemes;
+
 		//load core framework languages
 		foreach($codes as $code) {
 				$file = $path->locale . "ossn.{$code}.php";
@@ -396,10 +397,20 @@ function ossn_load_available_languages() {
 				}
 		}
 		//load component languages
-		$components = $components->getActive();
+		$components = $components->getComponents();
 		foreach($components as $component) {
 				foreach($codes as $code) {
-						$file = $path->components . '/' . $component->com_id . "/locale/ossn.{$code}.php";
+						$file = $path->components . '/' . $component . "/locale/ossn.{$code}.php";
+						if(is_file($file)) {
+								include_once($file);
+						}
+				}
+		}
+		//load theme languages
+		$themes = $themes->getThemes();
+		foreach($themes as $theme) {
+				foreach($codes as $code) {
+						$file = $path->themes . $theme . "/locale/ossn.{$code}.php";
 						if(is_file($file)) {
 								include_once($file);
 						}


### PR DESCRIPTION
aside from that I changed the code to load ALL installed locales, regardless whether components and themes are active or not,
because this makes sense on doing translation percentage checks.