### PR TITLE
prevent submitting of wallpost when pressing Enter in location input

### DIFF
--- a/components/OssnWall/plugins/default/js/ossn_wall.php
+++ b/components/OssnWall/plugins/default/js/ossn_wall.php
@@ -422,6 +422,12 @@ Ossn.RegisterStartupFunction(function() {
             var placesAutocomplete = places({
                 container: document.querySelector('#ossn-wall-location-input')
             });
+			$('#ossn-wall-location-input').keypress(function(event){
+				if(event.keyCode == 13) {
+					event.preventDefault();
+					return false;
+				}
+			});		
         }
     });
 });


### PR DESCRIPTION
see example of possible wrong usage in
https://www.opensource-socialnetwork.org/discussion/view/3964/post-location-does-not-work