### PR TITLE
Disable OssnChat automatically if OssnMesssges are disabled

### DIFF
--- a/components/OssnChat/ossn_com.php
+++ b/components/OssnChat/ossn_com.php
@@ -9,25 +9,29 @@
  * @link      https://www.opensource-socialnetwork.org/
  */
 define('__OSSN_CHAT__', ossn_route()->com . 'OssnChat/');
-require_once(__OSSN_CHAT__ . 'classes/OssnChat.php');
-require_once(__OSSN_CHAT__ . 'libs/ossn.lib.chat.php');
+if(com_is_active('OssnMessages')) {
+	require_once(__OSSN_CHAT__ . 'classes/OssnChat.php');
+	require_once(__OSSN_CHAT__ . 'libs/ossn.lib.chat.php');
+}
 
 function ossn_chat_init() {
-    ossn_extend_view('css/ossn.default', 'css/OssnChat');
+	if(com_is_active('OssnMessages')) {
+	    ossn_extend_view('css/ossn.default', 'css/OssnChat');
 
-    ossn_new_js('ossn.chat', 'js/OssnChat');
+	    ossn_new_js('ossn.chat', 'js/OssnChat');
 
-    //chat bar
-    if (ossn_isLoggedIn()) {
-        //load js and chatbar if user is loggedin
-        ossn_load_js('ossn.chat');
-        ossn_extend_view('ossn/page/footer', 'chat/chatbar');
-    }
-    ossn_register_page('ossnchat', 'ossn_js_page_handler');
+	    //chat bar
+	    if (ossn_isLoggedIn()) {
+	        //load js and chatbar if user is loggedin
+ 	       ossn_load_js('ossn.chat');
+  	      ossn_extend_view('ossn/page/footer', 'chat/chatbar');
+ 	   }
+ 	   ossn_register_page('ossnchat', 'ossn_js_page_handler');
 
-    ossn_register_action('ossnchat/send', __OSSN_CHAT__ . 'actions/message/send.php');
-    ossn_register_action('ossnchat/markread', __OSSN_CHAT__ . 'actions/markread.php');
-    ossn_register_action('ossnchat/close', __OSSN_CHAT__ . 'actions/close.php');
+ 	   ossn_register_action('ossnchat/send', __OSSN_CHAT__ . 'actions/message/send.php');
+ 	   ossn_register_action('ossnchat/markread', __OSSN_CHAT__ . 'actions/markread.php');
+	   ossn_register_action('ossnchat/close', __OSSN_CHAT__ . 'actions/close.php');
+	}
 }
 
 function ossn_js_page_handler($pages) {


### PR DESCRIPTION
as we are currently getting a crash on disabling OssnMessages if OssnChat is still alive

in longer terms we might enhance the Component's admin backend to check dependencies like that BEFORE allowing to disable a component which others are relying on