### PR TITLE
prevent crash on deleting comment when Notifications are disabled

### DIFF
--- a/components/OssnComments/ossn_com.php
+++ b/components/OssnComments/ossn_com.php
@@ -11,6 +11,9 @@
 define('__OSSN_COMMENTS__', ossn_route()->com . 'OssnComments/');
 require_once(__OSSN_COMMENTS__ . 'classes/OssnComments.php');
 require_once(__OSSN_COMMENTS__ . 'libs/comments.php');
+if(!com_is_active('OssnNotifications')) {
+	require_once(ossn_route()->com . 'OssnNotifications/classes/OssnNotifications.php');
+}
 
 /**
  * Initialize Comments Component


### PR DESCRIPTION
Admittedly a rare case that Notifications are disabled. But basically I think, if something CAN be disabled regularly from the admin backend, it shouldn't result in crashing.