### PR TITLE
removed unnecessary high z-index from love and like emoji

### DIFF
--- a/components/OssnLikes/plugins/default/css/likes.php
+++ b/components/OssnLikes/plugins/default/css/likes.php
@@ -905,16 +905,6 @@
 .ossn-reaction-title-wholiked {
 	 margin-left:10px;
 }
-.ossn-reaction-list li .emoji--like {
-	z-index:999;
-}
-.ossn-reaction-list li .emoji--love {
-	/*margin-left: -66px;*/
-	z-index:998;
-}
-.ossn-reaction-list li .emoji--haha {
-	/*margin-left: -77px;*/
-}
 .ossn-reaction-list .emoji__eyes:after,
 .ossn-reaction-list .emoji__tongue,
 .ossn-reaction-list .emoji__eyebrows,


### PR DESCRIPTION
giving issues on GreenByGreen theme - see report of member odhed
https://www.opensource-socialnetwork.org/component/view/3817/greenbygreen

actually I can't find a reason why especially these 2 emojis need that high z-index, all others are working correctly without