### PR TITLE
[B] don't display a tab of a friend who deleted his account

### DIFF
--- a/components/OssnChat/plugins/default/chat/chatbar.php
+++ b/components/OssnChat/plugins/default/chat/chatbar.php
@@ -50,8 +50,10 @@
         if ($active_sessions) {
             foreach ($active_sessions as $user) {
                 $user = ossn_user_by_guid($user);
-                $friend['user'] = $user;
-                echo ossn_plugin_view('chat/selectfriend', $friend);
+                if($user) {
+                    $friend['user'] = $user;
+                    echo ossn_plugin_view('chat/selectfriend', $friend);
+                }
             }
         }
         ?>


### PR DESCRIPTION
steps to reproduce getting a nameless 'ghost' tab at the bottom

A and B were formerly chatting
A sees tab of B at the bottom
B is deleting his account (but the id of B remains in $_SESSION['ossn_chat_users'] of A)
A is switching to another page, or does a page reload
chatbar is called again and old code relies on that B is still available --> and displays tab without name