### PR TITLE
[E] allow exact addressing of edited post nodes

### DIFF
--- a/components/OssnWall/actions/wall/post/embed.php
+++ b/components/OssnWall/actions/wall/post/embed.php
@@ -17,10 +17,10 @@ $text = str_replace("\\\\", "\\", $text);
 /* LinkPreview support --------------------------------- */
 $preview_state = 'unchanged';
 $preview_html  = '';
+$post_guid     = input('guid');
 
 if (com_is_active('LinkPreview')) {
 	$preview_url   = input('preview');
-	$post_guid     = input('guid');
 	// check whether a preview is already attached to the post 
 	if($len = strlen($preview_url)) {
 		// if yes, check whether this url is still included in the text
@@ -116,6 +116,7 @@ $embed  = $return['text'];
 echo json_encode(array(
 	"text" => $embed,
 	"preview_state" => $preview_state,
-	"preview" => $preview_html
+	"preview" => $preview_html,
+	"item_guid" => 'id="activity-item-' . $post_guid . '"'
 ));
 exit;


### PR DESCRIPTION
since we get already a `id=\"activity-item-POSTGUID\"` inside XHR responses of NEW posts
(which may be used by follow-ups like the Readmore component)
this change will allow us to retrieve the same `id=\"activity-item-POSTGUID\"` with EDITED posts, too