### PR TITLE
[E] allow exact addressing of edited comment nodes

### DIFF
--- a/components/OssnComments/actions/comment/embed.php
+++ b/components/OssnComments/actions/comment/embed.php
@@ -10,12 +10,14 @@
  */
 //Post on edit not returning JSON type callback #1506
 header('Content-Type: application/json'); 
-$data   = str_replace('\n', '<br/>', input('content'));
-$data	= str_replace("\\\\", "\\", $data);
+$data = str_replace('\n', '<br/>', input('content'));
+$data = str_replace("\\\\", "\\", $data);
+$comment_guid = input('guid');
 $return = ossn_call_hook('comment:view', 'template:params', NULL, array('comment' => array('comments:post' => $data)));
 $embed  = $return['comment']['comments:post'];
 echo json_encode(array(
             "data" => $embed,
-            "process" => 1
+            "process" => 1,
+            "item_guid" => 'id="comments-item-' . $comment_guid . '"'
 ));
 exit;


### PR DESCRIPTION
since we get already a `id=\"comments-item-COMMENTGUID\"` inside XHR responses of NEW comments
(which may be used by follow-ups like the Readmore component)
this change will allow us to retrieve the same `id=\"comments-item-COMMENTGUID\"` with EDITED comments, too