### PR TITLE
make all-comments link work

### DIFF
--- a/components/OssnProfile/ossn_com.php
+++ b/components/OssnProfile/ossn_com.php
@@ -536,14 +536,17 @@ function ossn_profile_images_allcomments($callback, $type, $params) {
 				ossn_unregister_menu('commentall', 'entityextra');
 				switch($params['entity']->subtype) {
 						case 'file:profile:photo':
-								$url = ossn_site_url("photos/user/view/{$params['entity']->guid}");
+								$url = ossn_site_url("photos/user/view/{$params['entity']->guid}/all_comments");
 								break;
 						case 'file:profile:cover':
-								$url = ossn_site_url("photos/cover/view/{$params['entity']->guid}");
+								$url = ossn_site_url("photos/cover/view/{$params['entity']->guid}/all_comments");
+								break;
+						case 'file:ossn:aphoto':
+								$url = ossn_site_url("photos/view/{$params['entity']->guid}/all_comments");
 								break;
 				}
 				$comment = new OssnComments;
-				if($comment->countComments($params['entity']->guid, 'entity') > 5) {
+				if($comment->countComments($params['entity']->guid, 'entity') > 5 && !$params['full_view']) {
 						ossn_register_menu_item('entityextra', array(
 								'name' => 'commentall',
 								'href' => $url,


### PR DESCRIPTION
So here it all starts:
if we have less than 6 photos or not already in all-comments mode (=params['full_view'] is set - no link will be shown
if we have more than 5 photos and not already in all-comments mode - the link will be shown
if we click on the link, the additional 'all_comments' will be passed to OssnPhotos pagehandler - setting photo['full_view']
so the 3 viewers will receive either nothing (=false) or 'all_comments' (=true)