### PR TITLE
stop like emojis from overlapping topbar

### DIFF
--- a/components/OssnLikes/plugins/default/css/likes.php
+++ b/components/OssnLikes/plugins/default/css/likes.php
@@ -1049,7 +1049,6 @@
 	position: absolute;
 	height: 50px;
 	top: auto;
-	z-index: 999;
 	margin-top: -75px;
 	box-shadow: 0 1px 5px rgba(0, 0, 0, 0.2);
 	border-radius: 2em;


### PR DESCRIPTION
checked with other themes, and I don't see why it needs a z-index at all, at least not such a high one

![likeindex](https://user-images.githubusercontent.com/9904364/88479156-627cd100-cf4d-11ea-94b9-0bf8773cd9bd.jpg)
