### PR TITLE
prevent creating of new records if setting value is 0

### DIFF
--- a/classes/OssnSite.php
+++ b/classes/OssnSite.php
@@ -149,7 +149,7 @@ class OssnSite extends OssnDatabase {
 				}
 				$name     = trim($name);
 				$settings = $this->getSettings($name);
-				if($settings && isset($this->settings->setting_id) && !empty($this->settings->setting_id)) {
+				if($settings !== false && isset($this->settings->setting_id) && !empty($this->settings->setting_id)) {
 						$params['table']  = 'ossn_site_settings as s';
 						$params['names']  = array(
 								'value'


### PR DESCRIPTION
I think it wouldn't even need that additional
&& isset($this->settings->setting_id) && !empty($this->settings->setting_id
because either we get a complete record back or not, but leaving in place wouldn't hurt :)