### PR TITLE
[B] com_ids must be checked case-SENSITIVE

### DIFF
--- a/classes/OssnComponents.php
+++ b/classes/OssnComponents.php
@@ -184,7 +184,7 @@ class OssnComponents extends OssnDatabase {
 						 * @Reason: Initial;
 						 */
 						$this->statement("SELECT * FROM ossn_components
-			    						  WHERE (com_id='$com');");
+			    						  WHERE (com_id= BINARY '$com');");
 						$this->execute();
 						$CHECK = $this->fetch();
 						if(!isset($CHECK->active)) {


### PR DESCRIPTION
since we allow case-sensitive component directories, the com_ids have to be checked case-sensitive, too.

Currently we're getting a half-done installation (directory installed, but no db-entry) if
1. we have successfully installed a component namd 'ArsaLAN'
2. we're trying to install another component named 'arsalan'