### PR TITLE
preserve exact <br>\n sequence after editing

### DIFF
--- a/components/OssnComments/actions/comment/embed.php
+++ b/components/OssnComments/actions/comment/embed.php
@@ -10,7 +10,7 @@
  */
 //Post on edit not returning JSON type callback #1506
 header('Content-Type: application/json'); 
-$data = str_replace('\n', '<br/>', input('content'));
+$data = str_replace('\n', "<br/>\n", input('content'));
 $data = str_replace("\\\\", "\\", $data);
 $comment_guid = input('guid');
 $return = ossn_call_hook('comment:view', 'template:params', NULL, array('comment' => array('comments:post' => $data)));


### PR DESCRIPTION
a fresh load of a 2 lines comment gives
`line1 <br>\n line2`
without this change after ajax edit it becomes
`line1 <br> line2`
we didn't notice that up to now because the broswer's display is still correct
but it does confuse the Readmore component which relies on the original sequence

currently Readmore is overwriting the original action, but I want to get rid of that with the next Ossn release