### PR TITLE
don't check 'isActive' on uninstalled component

### DIFF
--- a/classes/OssnComponents.php
+++ b/classes/OssnComponents.php
@@ -466,7 +466,7 @@ class OssnComponents extends OssnDatabase {
 						"com_id='{$id}'"
 				);
 				$this->settings   = $this->select($params);
-				if($this->settings->active == 1) {
+				if($this->settings && $this->settings->active == 1) {
 						return true;
 				}
 				return false;


### PR DESCRIPTION
we do run into this if a component requires another component to be disabled (in xml file)
but this other component is not installed at all
gives warning "Attempt to read property "active" on bool"