### PR TITLE
adapted frontend system messages to BS 5

### DIFF
--- a/system/plugins/default/javascripts/libraries/ossn.lib.messageboxes.php
+++ b/system/plugins/default/javascripts/libraries/ossn.lib.messageboxes.php
@@ -79,7 +79,7 @@ Ossn.trigger_message = function($message, $type) {
 	if ($message == '') {
 		return false;
 	}
-	$html = "<div class='alert alert-" + $type + "'><a href=\"#\" class=\"close\" data-dismiss=\"alert\">&times;</a>" + $message + "</div>";
+	$html = "<div class='alert alert-dismissible alert-" + $type + "'><button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"alert\" aria-label=\"Close\"></button>" + $message + "</div>";
 	$('.ossn-system-messages').find('.ossn-system-messages-inner').append($html);
 	if ($('.ossn-system-messages').find('.ossn-system-messages-inner').is(":not(:visible)")) {
 		$('.ossn-system-messages').find('.ossn-system-messages-inner').slideDown('slow');


### PR DESCRIPTION
(same as on admin backend)

maybe we should think of setting
.btn-close {
	background-size: .7em;
}
because the close button appears a little oversized to my opinion by default