### PR TITLE
use same layout as on user and group form

### DIFF
--- a/components/OssnWall/plugins/default/forms/OssnWall/home/container.php
+++ b/components/OssnWall/plugins/default/forms/OssnWall/home/container.php
@@ -38,13 +38,13 @@ if (!isset($params['user']->guid)) {
 			echo ossn_view_menu('wall/container/controls/home', 'wall/menus/container_controls'); 
 		?>            
     </div>
-   <div class="ossn-wall-privacy">
-            <span><i class="ossn-wall-privacy-lock fa fa-lock"></i><span class=""><?php echo ossn_print('privacy'); ?></span></span>
-    </div>           
     <div class='ossn-wall-post-button-container'>
             <div class="ossn-loading ossn-hidden"></div>
             <input class="btn btn-primary ossn-wall-post" type="submit" value="<?php echo ossn_print('post'); ?>" />
     </div>
+    <div class="ossn-wall-privacy">
+            <span><i class="ossn-wall-privacy-lock fa fa-lock"></i><span class=""><?php echo ossn_print('privacy'); ?></span></span>
+    </div>           
     <input type="hidden" value="<?php echo $params['user']->guid; ?>" name="wallowner" />
     <input type="hidden" name="privacy" id="ossn-wall-privacy" value="<?php echo OSSN_PUBLIC; ?>" />
 </div>


### PR DESCRIPTION
PROFILE and GROUP container divs are using the sequence

- controls 
- button
- privacy

while this one was using
 
- controls
- privacy
- button

you won't notice the difference on goblue,
but as soon as you want to float the privacy div, you'll run into trouble:
HOME
![home-layout](https://user-images.githubusercontent.com/9904364/116943217-69223c80-ac73-11eb-9b39-224ef46376bd.JPG)
PROFILE
![profile-layout](https://user-images.githubusercontent.com/9904364/116943254-7a6b4900-ac73-11eb-9c5c-b0202f502adc.JPG)

so it makes sense to have the same layout in all 3 containers