### PR TITLE
PHP8 sanitizing

### DIFF
--- a/components/OssnProfile/classes/OssnProfile.php
+++ b/components/OssnProfile/classes/OssnProfile.php
@@ -75,22 +75,24 @@ class OssnProfile extends OssnDatabase {
 				             subtype='cover_position');");
         $this->execute();
         $entity = $this->fetch();
-        $position = array(
-            '',
-            ''
-        );
+	if($entity){
+        	$position = array(
+        	    '',
+        	    ''
+        	);
 
-        $fields = new OssnEntities;
-        $fields->owner_id = $guid;
-        $fields->guid = $entity->guid;
-        $fields->type = 'user';
+        	$fields = new OssnEntities;
+        	$fields->owner_id = $guid;
+        	$fields->guid = $entity->guid;
+        	$fields->type = 'user';
 
-        $fields->subtype = 'cover_position';
-        $fields->value = json_encode($position);
-        if ($fields->updateEntity()) {
-            return true;
-        }
-        return false;
+        	$fields->subtype = 'cover_position';
+        	$fields->value = json_encode($position);
+        	if ($fields->updateEntity()) {
+        	    return true;
+        	}
+        	return false;
+	}
     }
 
     /**


### PR DESCRIPTION
Having a closer look into this:
if a member is uploading a cover image for the 1st time - there is still NO 'cover_position' entity, so in fact nothing can be updated.
we may add that record here in a case like that,
on the other hand it's not absolutely necessary, because the javascript is smart enough to handle dragging without data-left and data-top being set
and the record will be created after the first repositioning anyway