### PR TITLE
PHP 8 sanitizing

### DIFF
--- a/components/OssnPhotos/ossn_com.php
+++ b/components/OssnPhotos/ossn_com.php
@@ -419,6 +419,7 @@ function ossn_album_page_handler($album) {
 						$guid    = $album[1];
 						$picture = $album[2];
 						$type    = input('type');
+						$size    = input('size');
 						
 						$name = str_replace(array(
 								'.jpg',


### PR DESCRIPTION
actually, currently getcover is not called with a size parameter at all.
so the other choice would be to remove $size completely ...