### PR TITLE
[E] removed dominant comment-box padding

### DIFF
--- a/components/OssnSmilies/plugins/default/css/smilies/emojii.php
+++ b/components/OssnSmilies/plugins/default/css/smilies/emojii.php
@@ -87,15 +87,6 @@
 	top: 105px;
 }
 
-
-/***************************************
-	Override the comment box width
-****************************************/
-
-.comment-box {
-	padding: 6px 65px 6px 12px !important;
-}
-
 .comment-container {
 	z-index: initial;
 }


### PR DESCRIPTION
the same setting is in goblue already anyway, see #1942
and the comment-box styling should be handled in the themes css