### PR TITLE
removed obsolete code (typo)

### DIFF
--- a/components/OssnWall/classes/OssnWall.php
+++ b/components/OssnWall/classes/OssnWall.php
@@ -183,10 +183,6 @@ class OssnWall extends OssnObject {
 								'value'  => true,
 								'wheres' => '(1=1)',
 						);
-						$user_posts = array(
-								'name'  => 'poster_guid',
-								'value' => true,
-						);
 						if(ossn_isLoggedin() && (ossn_user_is_friend(ossn_loggedin_user()->guid, $user->guid) || ossn_loggedin_user()->guid == $user->guid || ossn_isAdminLoggedin())){
 								$users_posts['wheres']       = "((emd0.value=2 OR emd0.value=3) AND [this].value IN({$friend_guids}))";
 								$default['entities_pairs'][] = $users_posts;


### PR DESCRIPTION
i think it was a typo in first place: it was $user_posts here, but entities_pairs are filled with $userS_posts.
so $user_posts never becomes a part of the query
on the other hand the id of the profile page owner is guaranteed to be included already in the friends array on line 172, so it's an unnecessary duplicate anyway and can be removed