### PR TITLE
normal users are unable to delete their post on group wall

### DIFF
--- a/components/OssnWall/actions/wall/post/delete.php
+++ b/components/OssnWall/actions/wall/post/delete.php
@@ -12,7 +12,7 @@ $ossnwall = new OssnWall;
 $id = input('post');
 $post = $ossnwall->GetPost($id);
 if ($post->type == 'user' && !ossn_isAdminLoggedin()) {
-    if ($post->poster_guid !== ossn_loggedin_user()->guid && $post->owner_guid !== ossn_loggedin_user()->guid) {
+    if ($post->poster_guid != ossn_loggedin_user()->guid && $post->owner_guid !== ossn_loggedin_user()->guid) {
         if (!ossn_is_xhr()) {
             ossn_trigger_message(ossn_print('post:delete:fail'), 'error');
             redirect(REF);
@@ -27,7 +27,7 @@ if ($post->type == 'group' && !ossn_isAdminLoggedin()) {
     $group = $group->getGroup($post->owner_guid);
 	//lastchange group admins are unable to delete member posting on group wall #171
 	// change or operator to and
-    if (($post->poster_guid !== ossn_loggedin_user()->guid) && (ossn_loggedin_user()->guid !== $group->owner_guid)) {
+    if ($post->poster_guid != ossn_loggedin_user()->guid && ossn_loggedin_user()->guid !== $group->owner_guid) {
         if (!ossn_is_xhr()) {
             ossn_trigger_message(ossn_print('post:delete:fail'), 'error');
             redirect(REF);


### PR DESCRIPTION
we must not use !== when comparing entity value (=STRING) with user_guid (=INT)