### PR TITLE
Fixed: jfif photo uploads don't work

### DIFF
--- a/classes/OssnFile.php
+++ b/classes/OssnFile.php
@@ -385,6 +385,9 @@ class OssnFile extends OssnEntities {
 						'jpeg' => array(
 								'image/jpeg'
 						),
+						'jfif' => array(
+						        'image/jpeg'
+						),
 						'jpg' => array(
 								'image/jpeg'
 						),

--- a/classes/mail/class.phpmailer.php
+++ b/classes/mail/class.phpmailer.php
@@ -4229,6 +4229,7 @@ class PHPMailer{
             'bmp' => 'image/bmp',
             'gif' => 'image/gif',
             'jpeg' => 'image/jpeg',
+            'jfif' => 'image/jpeg',
             'jpe' => 'image/jpeg',
             'jpg' => 'image/jpeg',
             'png' => 'image/png',

--- a/components/OssnAds/classes/OssnAds.php
+++ b/components/OssnAds/classes/OssnAds.php
@@ -37,6 +37,7 @@ class OssnAds extends OssnObject {
 										'jpg',
 										'png',
 										'jpeg',
+										'jfif',
 										'gif'
 								));
 								$this->OssnFile->setPath('ossnads/images/');

--- a/components/OssnComments/classes/OssnComments.php
+++ b/components/OssnComments/classes/OssnComments.php
@@ -93,6 +93,7 @@ class OssnComments extends OssnAnnotation {
 										'jpg',
 										'png',
 										'jpeg',
+										'jfif',
 										'gif'
 								));
 								$file->owner_guid = $this->getAnnotationId();

--- a/components/OssnGroups/classes/OssnGroup.php
+++ b/components/OssnGroups/classes/OssnGroup.php
@@ -446,6 +446,7 @@ class OssnGroup extends OssnObject {
 						'jpg',
 						'png',
 						'jpeg',
+						'jfif',
 						'gif'
 				));
 				$this->OssnFile->setPath('cover/');

--- a/components/OssnPhotos/classes/OssnPhotos.php
+++ b/components/OssnPhotos/classes/OssnPhotos.php
@@ -41,6 +41,7 @@ class OssnPhotos extends OssnFile {
 								'jpg',
 								'png',
 								'jpeg',
+								'jfif',
 								'gif'
 						));
 						

--- a/components/OssnProfile/actions/cover/upload.php
+++ b/components/OssnProfile/actions/cover/upload.php
@@ -21,6 +21,7 @@ $file->setExtension(array(
 		'jpg',
 		'png',
 		'jpeg',
+		'jfif',
 		'gif'
 ));
 if($fileguid = $file->addFile()) {

--- a/components/OssnProfile/actions/photo/upload.php
+++ b/components/OssnProfile/actions/photo/upload.php
@@ -22,6 +22,7 @@ $file->setExtension(array(
 		'jpg',
 		'png',
 		'jpeg',
+		'jfif',
 		'gif'
 ));
 

--- a/components/OssnWall/classes/OssnWall.php
+++ b/components/OssnWall/classes/OssnWall.php
@@ -83,6 +83,7 @@ class OssnWall extends OssnObject {
 										'jpg',
 										'png',
 										'jpeg',
+										'jfif',
 										'gif',
 								));
 								$this->OssnFile->addFile();

--- a/libraries/minify/CSSmin.php
+++ b/libraries/minify/CSSmin.php
@@ -35,6 +35,7 @@ class CSSmin extends Minify {
         'jpe' => 'data:image/jpeg',
         'jpg' => 'data:image/jpeg',
         'jpeg' => 'data:image/jpeg',
+        'jfif' => 'data:image/jpeg',
         'svg' => 'data:image/svg+xml',
         'woff' => 'data:application/x-font-woff',
         'tif' => 'image/tiff',

--- a/themes/goblue/actions/settings.php
+++ b/themes/goblue/actions/settings.php
@@ -41,6 +41,7 @@ $admin->setFile('logo_admin');
 $admin->setExtension(array(
 		'jpg',
 		'jpeg',
+		'jfif',
 ));
 if(isset($admin->file['tmp_name']) && $admin->typeAllowed()){
 	$file = $admin->file['tmp_name'];


### PR DESCRIPTION
## Background

Since a Windows update in December 2019, Microsoft has configured all of its customers' computers to use .jfif instead of .jpg as the default extension when saving JPEG files:

https://answers.microsoft.com/en-us/windows/forum/all/jpg-vs-jfif-extension/f66875d7-4780-4d55-b8da-9387de4139d4

Since the .jfif protocol has not been widely popular, it is not presently supported by OSSN.

We need to make sure that .jfif uploads work as well as .jpg uploads do.

## Solution

In a handful of places, an configuration is sent to ```OssnFile::setExtension()``` that defines allowed file types. Wherever there has been found ".jpg" and ".jpeg" file extensions in that configuration, I have added ".jfif". 

I also added the reverse mapping (".jfif" to "image/jpeg" mime type) in the applicable places.

The original issue is found here: [jfif photo uploads don't work #7](https://github.com/AntzCode/opensource-socialnetwork/issues/7)

The revision in the main branch of my OSSN fork is here: [baa0cb71e587c36ff7499aa5b60c9114d8594d70](https://github.com/AntzCode/opensource-socialnetwork/commit/baa0cb71e587c36ff7499aa5b60c9114d8594d70)

## Notes

* This affects a Third Party library (phpMailer). 
* This is a high priority bug because it probably affects most Windows users.

