### PR TITLE
PHP 8 sanitizing

### DIFF
--- a/actions/administrator/user/edit.php
+++ b/actions/administrator/user/edit.php
@@ -32,7 +32,7 @@ if (!empty($user)) {
         }
     }
 }
-if($fields['non_required']) {
+if(isset($fields['non_required'])) {
 	foreach($fields['non_required'] as $field){
 		$user[$field] = input($field);
 	}


### PR DESCRIPTION
fixed check on non_required fields
(throwing 'Undefined array key' if not available)