### PR TITLE
make invisible groups icon visible on search page

### DIFF
--- a/themes/goblue/plugins/default/css/core/default.php
+++ b/themes/goblue/plugins/default/css/core/default.php
@@ -1797,7 +1797,7 @@ li[class^="menu-section-item-"] {
 .ossn-menu-search-users .text:before {
 	font-family: 'Font Awesome 5 Free';
 	content: "\f007";
-	display: absolute;
+	font-weight: 900;
 	padding-right: 10px;
 	vertical-align: middle;
 	float: left;
@@ -1806,7 +1806,7 @@ li[class^="menu-section-item-"] {
 .ossn-menu-search-groups .text:before {
 	font-family: 'Font Awesome 5 Free';
 	content: "\f0c0";
-	display: absolute;
+	font-weight: 900;
 	padding-right: 10px;
 	vertical-align: middle;
 	float: left;


### PR DESCRIPTION
problem is, that not every FA 5 icon is available as outlined (as f0c0 for example)
so we should use solid (weight 900) on the search page by default