### PR TITLE
make video visible in <span>

### DIFF
--- a/components/OssnEmbed/plugins/default/css/embed.php
+++ b/components/OssnEmbed/plugins/default/css/embed.php
@@ -1,0 +1,3 @@
+.ossn_embed_video {
+	display: block;
+}


### PR DESCRIPTION
this rule came included with former Bootstrap 'embed_responsive' - but is missing in 'ratio' of new Bootstrap