### PR TITLE
[B] fixed unallowed <div> inside paragraph again

### DIFF
--- a/components/OssnEmbed/libraries/ossnembed.lib.php
+++ b/components/OssnEmbed/libraries/ossnembed.lib.php
@@ -92,7 +92,7 @@ function ossn_embed_add_css($guid, $width, $height) {
  * @return string <object> code
  */
 function ossn_embed_add_object($type, $url, $guid, $width, $height) {
-	$videodiv = "<div id=\"ossnembed{$guid}\" class=\"ossn_embed_video ratio ratio-16x9 embed-responsive embed-responsive-16by9\">";
+	$videodiv = "<span id=\"ossnembed{$guid}\" class=\"ossn_embed_video ratio ratio-16x9\">";
 
 	// could move these into an array and use sprintf
 	switch ($type) {
@@ -111,7 +111,7 @@ function ossn_embed_add_object($type, $url, $guid, $width, $height) {
 			break;
 	}
 
-	$videodiv .= "</div>";
+	$videodiv .= "</span>";
 	// re-open post-text again (last closing </div> comes with wall code as before )
 	// hmm no need for div post-text without ending tag , removed it from here and removed ending tag from ossn_embed_add_css() 
 	// $arsalanshah 12/4/2015
@@ -193,7 +193,7 @@ function ossn_embed_youtube_parse_url($url) {
  * @param string $url
  * @return string youtube.com/v/hash
  */
-function ossn_embed_youtube_shortener_parse_url($url) {
+function ossn_embed_youtube_shortener_parse_url($url, $guid, $videowidth) {
 	$path = parse_url($url, PHP_URL_PATH);
 	$videourl = 'youtube.com/embed' . $path;
 


### PR DESCRIPTION
I had fixed that already in Oct 2016 (see history) but it became reverted back to wrong html again with #1957
this way the post is getting messed up because browsers are putting that div outside of the paragraph
one result is that READMORE fails because of that split

plus:
- removed no more available old bootstrap classes embed-responsive
- fix for missing video id with youtu.be videos ('undefined variable $guid' logs)