### PR TITLE
[B] fixed missing error handler for not existing subpages

### DIFF
--- a/components/OssnProfile/ossn_com.php
+++ b/components/OssnProfile/ossn_com.php
@@ -270,7 +270,7 @@ function profile_page_handler($page) {
 				$params['subpage'] = '';
 		}
 		if(!ossn_is_profile_subapge($params['subpage']) && !empty($params['subpage'])) {
-				return false;
+				ossn_error_page();
 		}
 		$title               = $user->fullname;
 		$vars                = array(


### PR DESCRIPTION
former code returned a blank page on calling /u/existing_member/not_existing_subpage