### PR TITLE
[E] PHP8 prevent bool->guid warnings

### DIFF
--- a/components/OssnGroups/ossn_com.php
+++ b/components/OssnGroups/ossn_com.php
@@ -145,7 +145,7 @@ function ossn_group_load_event($event, $type, $params) {
 		ossn_register_menu_link('members', 'members', ossn_group_url($owner) . 'members', 'groupheader');
 		// show 'Requests' menu tab only on pending requests
 		$group = ossn_get_group_by_guid($owner);
-		if($group){
+		if(ossn_isLoggedin() && $group){
 			if ($group->countRequests() && ($group->owner_guid == ossn_loggedin_user()->guid || ossn_isAdminLoggedin() || $group->isModerator(ossn_loggedin_user()->guid))) {
 				ossn_register_menu_link('requests', 'requests', ossn_group_url($owner) . 'requests', 'groupheader');
 			}


### PR DESCRIPTION
if group is visited without being logged in
(this may happen more often now with new UnloggedinMenu component)