### PR TITLE
[E] optimized group join-requests counter

### DIFF
--- a/components/OssnGroups/classes/OssnGroup.php
+++ b/components/OssnGroups/classes/OssnGroup.php
@@ -178,15 +178,25 @@ class OssnGroup extends OssnObject {
 		 * @return int;
 		 */
 		public function countRequests(){
-				$count = $this->getMembersRequests();
-				if(!$count){
-						return false;
-				}
-				$cc = 0;
-				foreach ($count as $c){
-						$cc++;
-				}
-				return $cc;
+				$group = $this->guid;
+
+				$this->statement("SELECT COUNT(*) as join_requests FROM ossn_relationships  WHERE(
+					relation_to='{$group}' AND
+					type='group:join'
+				);");
+				$this->execute();
+				$from = $this->fetch(false);
+				$join_requests = $from->join_requests;
+
+				$this->statement("SELECT COUNT(*) as approved_members FROM ossn_relationships WHERE(
+					relation_from='{$group}' AND
+					type='group:join:approve'
+				);");
+				$this->execute();
+				$from = $this->fetch(false);
+				$approved_members = $from->approved_members;
+
+				return $join_requests - $approved_members;
 		}
 
 		/**


### PR DESCRIPTION
Logic:
Every approved member MUST HAVE a group:join record already, and so we can count them indirectly by counting the group:join:approved records.
Now, if we do a second count on group:join records, the difference between the first and the second count is exactly the number of not yet approved members.
If the difference = 0, every member must have been approved. :)