### PR TITLE
[E] avoid unnecessary OssnGroup::countRequests() calls

### DIFF
--- a/components/OssnGroups/ossn_com.php
+++ b/components/OssnGroups/ossn_com.php
@@ -146,7 +146,7 @@ function ossn_group_load_event($event, $type, $params) {
 		// show 'Requests' menu tab only on pending requests
 		$group = ossn_get_group_by_guid($owner);
 		if($group){
-			if ($group->countRequests() && ($group->owner_guid == ossn_loggedin_user()->guid || ossn_isAdminLoggedin() || $group->isModerator(ossn_loggedin_user()->guid))) {
+			if (($group->owner_guid == ossn_loggedin_user()->guid || ossn_isAdminLoggedin() || $group->isModerator(ossn_loggedin_user()->guid)) && $group->countRequests()) {
 				ossn_register_menu_link('requests', 'requests', ossn_group_url($owner) . 'requests', 'groupheader');
 			}
 		}


### PR DESCRIPTION
if page visitor is neither admin nor group owner nor moderator
since normal visitors would never see that 'Member Request' tab anyway