### PR TITLE
[B] PHP Warning: preg_match(): Compilation failed (#2018).

### DIFF
--- a/installation/classes/OssnInstall.php
+++ b/installation/classes/OssnInstall.php
@@ -201,7 +201,7 @@ class OssnInstallation {
 		 *
 		 */
 		public function dbhost($dbhost) {
-				preg_match('/([\w-\.]+)(|\:(\d+))$/', $dbhost, $matches);
+				preg_match('/([\w\.-]+)(|\:(\d+))$/', $dbhost, $matches);
 				//set the host without port
 				if(isset($matches[1])){
 					$dbhost = $matches[1];


### PR DESCRIPTION
This PR should fix:

```
PHP Warning: preg_match(): Compilation failed: invalid range in character class at offset 4 in /var/www/ossn/installation/classes/OssnInstall.php on line 209', referer: installation/?page=settings
```