### PR TITLE
fixed typo

### DIFF
--- a/components/OssnPhotos/ossn_com.php
+++ b/components/OssnPhotos/ossn_com.php
@@ -201,7 +201,7 @@ function ossn_notification_like_photo($hook, $type, $return, $notification) {
 		if(preg_match('/comments/i', $notification->type)) {
 				$iconType = 'comment';
 		}
-		$url = ossn_site_url("photos/view/{$notif->subject_guid}");
+		$url = ossn_site_url("photos/view/{$notification->subject_guid}");
 		return ossn_plugin_view('notifications/template/view', array(
 				'iconURL'   => $user->iconURL()->small,
 				'guid'      => $notification->guid,


### PR DESCRIPTION
**this typo was leading my attention to extra bugs that have to be fixed:**
1) entering just 'photos/view/' gives a SQL crash in searchFiles() because of wrong condition in the beginning
2) entering 'photos/view/ANY_WRONG_ID' gives later crash because of missing error checks in view part of ossn_photos_page_handler