### PR TITLE
[E] fixed different 'readonly' colors

### DIFF
--- a/system/plugins/default/forms/admin/user/edit.php
+++ b/system/plugins/default/forms/admin/user/edit.php
@@ -20,7 +20,7 @@ $user = $params['user'];
 </div>
 <div>
 	<label> <?php echo ossn_print('username'); ?>  </label>
-	<input type='text' name="username" value="<?php echo $user->username; ?>" style="background:#E8E9EA;" readonly="readonly"/>
+	<input type='text' class="form-control" name="username" value="<?php echo $user->username; ?>" readonly="readonly"/>
 </div>
 <div>
 	<label> <?php echo ossn_print('email'); ?> </label>


### PR DESCRIPTION
while birthdate gets a bootstrap color via user/fields/item.php->form-control, username had it's own defined style color which is different

maybe it makes sense to add form-control to the other fields, too, as done in the signup form ...