### PR TITLE
[B] prevent returning undefined $user_fields

### DIFF
--- a/libraries/ossn.lib.users.php
+++ b/libraries/ossn.lib.users.php
@@ -449,7 +449,9 @@ function ossn_user_fields_names() {
 								}
 						}
 				}
-				return $user_fields;
+				if(isset($user_fields)) {
+						return $user_fields;
+				}
 		}
 		return false;
 }

--- a/libraries/ossn.lib.users.php
+++ b/libraries/ossn.lib.users.php
@@ -428,7 +428,9 @@ function ossn_prepare_user_fields($user = '') {
 								}
 						}
 				}
-				return $user_fields;
+				if(isset($user_fields)) {
+						return $user_fields;
+				}
 		}
 		return false;
 }


### PR DESCRIPTION
example: if RemoveGenders and RemoveBirthdate components are enabled, there's no $user_fields