### PR TITLE
[B] fix allowing to display profile modules with priority < 200

### DIFF
--- a/components/OssnProfile/ossn_com.php
+++ b/components/OssnProfile/ossn_com.php
@@ -223,7 +223,7 @@ function profile_search_handler($hook, $type, $return, $params) {
  *
  * @return modules;
  */
-function profile_modules($h, $t, $module, $params) {
+function profile_modules($h, $t, $modules, $params) {
 		$user['user'] = $params['user'];
 		
 		// didn't part of initial release , so in next release we will add
@@ -233,12 +233,12 @@ function profile_modules($h, $t, $module, $params) {
 		$content = ossn_plugin_view("profile/modules/friends", $user);
 		$title   = ossn_print('friends');
 		
-		$module[] = ossn_view_widget(array(
+		$modules[] = ossn_view_widget(array(
 				'title' => $title,
 				'contents' => $content
 		));
 		
-		return $module;
+		return $modules;
 }
 /**
  * Add user profile picture on sidebar of newsfeed

--- a/components/OssnProfile/ossn_com.php
+++ b/components/OssnProfile/ossn_com.php
@@ -233,12 +233,12 @@ function profile_modules($h, $t, $module, $params) {
 		$content = ossn_plugin_view("profile/modules/friends", $user);
 		$title   = ossn_print('friends');
 		
-		$modules[] = ossn_view_widget(array(
+		$module[] = ossn_view_widget(array(
 				'title' => $title,
 				'contents' => $content
 		));
 		
-		return $modules;
+		return $module;
 }
 /**
  * Add user profile picture on sidebar of newsfeed


### PR DESCRIPTION
Yeah, long time not noticed ;)
Actually, I was trying to display the output of the aboutuser component as FIRST module on the proflle page and wondering why it did not work...
![screenshot-minimickl fritz box-2022 12 02-16_51_35](https://user-images.githubusercontent.com/9904364/205333890-ef17a3c4-8cbc-40d4-adda-2898e22b926a.png)
