### PR TITLE
User existence check

### DIFF
--- a/components/OssnInvite/ossn_com.php
+++ b/components/OssnInvite/ossn_com.php
@@ -67,7 +67,7 @@ function ossn_invite_pagehandler(){
  */
 function ossn_invite_addfriends($callback, $type, $params){
 	   $friend = input('com_invite_friend');
-	   if (isset($params['guid']) && !empty($params['guid']) && isset($friend) && !empty($friend) && ossn_user_by_guid($friend)!=false) {
+	   if (isset($params['guid']) && !empty($params['guid']) && isset($friend) && !empty($friend) && !ossn_user_by_guid($friend)) {
 				ossn_add_friend($friend, $params['guid']);
 				ossn_add_friend($params['guid'], $friend);
 	   }

--- a/components/OssnInvite/ossn_com.php
+++ b/components/OssnInvite/ossn_com.php
@@ -67,7 +67,7 @@ function ossn_invite_pagehandler(){
  */
 function ossn_invite_addfriends($callback, $type, $params){
 	   $friend = input('com_invite_friend');
-	   if(isset($params['guid']) && !empty($params['guid']) && isset($friend) && !empty($friend)){
+	   if (isset($params['guid']) && !empty($params['guid']) && isset($friend) && !empty($friend) && ossn_user_by_guid($friend)!=false) {
 				ossn_add_friend($friend, $params['guid']);
 				ossn_add_friend($params['guid'], $friend);
 	   }


### PR DESCRIPTION
Currently OSSN assumes that the inviting user is still on the network when the guest registers. But if between sending the link and registering the guest the user deletes his account, an error occurs. Additional verification prevents the error.

I am sending this PR because this situation happened at my client