### PR TITLE
Revert to former profile picture if current one has been deleted

### DIFF
--- a/classes/OssnUser.php
+++ b/classes/OssnUser.php
@@ -987,7 +987,7 @@ class OssnUser extends OssnEntities {
 						return ossn_get_file($this->icon_guid);
 				}
 				//fallback to old picture selection solution
-				if(!empty($this->guid) && !isset($this->icon_guid)) {
+				if(!empty($this->guid) && (!isset($this->icon_guid) || isset($this->icon_guid) && empty($this->icon_guid))) {
 						$this->owner_guid = $this->guid;
 						$this->type       = 'user';
 						$this->subtype    = 'file:profile:photo';


### PR DESCRIPTION
if I remember right, once it was working, but currently it's not, because: when I delete my current profile picture, the icon_id value gets deleted correctly from metadata, but the rows are  still in place in entities/metadata so without checking this additional condition, we never reach line 991 and old pics are lost