### PR TITLE
[E] OssnNotifications check new one on mark all as read

### DIFF
--- a/components/OssnNotifications/plugins/default/js/OssnNotifications.php
+++ b/components/OssnNotifications/plugins/default/js/OssnNotifications.php
@@ -255,6 +255,8 @@ Ossn.RegisterStartupFunction(function() {
         				callback: function(callback) {
            					if(callback['success']){
 								Ossn.trigger_message(callback['success']);
+								Ossn.NotificationBoxClose();
+								Ossn.NotificationsCheck();
 							}
 							if(callback['error']){
 								Ossn.trigger_message(callback['error']);								


### PR DESCRIPTION
Close notification window and clear the counter when click on mark all read. Otherwise, the notification window still open and notifications remains until the update from Ossn.NotificationsCheck();

![image](https://github.com/opensource-socialnetwork/opensource-socialnetwork/assets/3620428/a4a9b954-95a8-41f0-84bd-53a4b5041abc)
